### PR TITLE
Add figshare link

### DIFF
--- a/source/cite/index.rst
+++ b/source/cite/index.rst
@@ -15,6 +15,15 @@ The following are notable publications regarding |cyclus|:
    :list: enumerated
    :enumtype: upperroman
 
+|Cyclus| Presentations
+-----------------------
+
+The following are presentations given about |cyclus|:
+
+* `Cyclus: Next Generation Fuel Cycle Simulator <http://dx.doi.org/10.6084/m9.figshare.1278926>`_, presented at the Fuel Cycle Options Campaign meeting, 12/16/14, Las Vegas, NV
+* `Market-Based and System-Wide Fuel Cycle Optimization <http://figshare.com/articles/Market_Based_and_System_Wide_Fuel_Cycle_Optimization/1278937>`_, presented at the Fuel Cycle Options Campaign meeting, 12/16/14, Las Vegas, NV
+   
+
 
 |Cyclus| Meetings and Tutorials
 -------------------------------

--- a/source/cite/meetings/2014.10.23.ANL.rst
+++ b/source/cite/meetings/2014.10.23.ANL.rst
@@ -13,8 +13,7 @@ Agenda
 | 8:20    | Introductory Comments by DOE Technical                           | B. Dixon (INL)         |
 |         | Point of Conctact for  Cyclus Related-Activities                 |                        |
 +---------+------------------------------------------------------------------+------------------------+
-| 8:30    | Cyclus Development: History, Strategy, Contributors,             | P. Wilson (U. Wisc)    |
-|         | Funding, Future Developmental Needs, and Potential Users         |                        |
+| 8:30    | |830_wilson|_                                                    | P. Wilson (U. Wisc)    |
 +---------+------------------------------------------------------------------+------------------------+
 | 9:30    | Cyclus v1.1 Status and Capabilities                              | Scopatz (U. Wisc)      | 
 +---------+------------------------------------------------------------------+------------------------+
@@ -43,3 +42,6 @@ Agenda
 | 15:45   | Cyclus Community/Ecosystem Roadmap                               | Scopatz (U. Wisc)      |
 +---------+------------------------------------------------------------------+------------------------+
 
+.. |830_wilson| replace:: Cyclus Development: History, Strategy, Contributors, Funding, Future Developmental Needs, and Potential Users
+
+.. _820_wilson: http://dx.doi.org/10.6084/m9.figshare.1285435


### PR DESCRIPTION
Finally got time to make my Cyclus build work and publish the last PR.  This one adds the Vegas presentations and a demo link for the ANL meeting using substitutions to preserve the table formatting.