### PR TITLE
fixes and support for recursive alias and containers

### DIFF
--- a/source/atemplates/layout.html
+++ b/source/atemplates/layout.html
@@ -4,11 +4,11 @@
   <div class="sphinxlocaltoc">
   <h3>{{ _('Useful Pages') }}</h3>
     <ul><li><ul>
-    <li><a href="http://fuelcycle.org/user/index.html">User Guide</a></li>
-    <li><a href="http://fuelcycle.org/arche/index.html">Archetype Developer Guide</a></li>
-    <li><a href="http://fuelcycle.org/cyclus/api/">Cyclus API Documentation</a></li>
-    <li><a href="http://fuelcycle.org/cycamore/api/">Cycamore API Documentation</a></li>
-    <li><a href="http://fuelcycle.org/basics/glossary.html">Glossary</a></li>
+    <li><a href="/user/index.html">User Guide</a></li>
+    <li><a href="/arche/index.html">Archetype Developer Guide</a></li>
+    <li><a href="/cyclus/api/">Cyclus API Documentation</a></li>
+    <li><a href="/cycamore/api/">Cycamore API Documentation</a></li>
+    <li><a href="/basics/glossary.html">Glossary</a></li>
     <li><a href="mailto:cyclus-users+subscribe@googlegroups.com?subject=Subscribe&body=Send this message to subscribe to the list">Join</a> the 
       <a href="https://groups.google.com/forum/#!forum/cyclus-users" target="_blank"><span style="font-variant:small-caps">Cyclus</span> Users</a> mailing list.
     <li><a href="mailto:cyclus-dev+subscribe@googlegroups.com?subject=Subscribe&body=Send this message to subscribe to the list">Join</a> the 

--- a/source/cyclusagent.py
+++ b/source/cyclusagent.py
@@ -42,19 +42,24 @@ elif sys.version_info[0] >= 3:
     STRING_TYPES = (str,)
     IS_PY3 = True
 
-PRIMITIVES = {'bool', 'int', 'float', 'double', 'std::string', 'cyclus::Blob', 
-              'boost::uuids::uuid', 'cyclus::toolkit::ResourceBuff',
-              'cyclus::Material', 'cyclus::Resource', 'cyclus::Product'}
+def contains_resbuf(type_str):
+    bufs = ('cyclus::toolkit::ResBuf',
+            'cyclus::toolkit::ResMap',
+            'cyclus::toolkit::ResourceBuff')
+    for buf in bufs:
+        if buf in type_str:
+            return True
+    return False
 
 def ensure_tuple_or_str(x):
     if isinstance(x, STRING_TYPES):
         return x
     else:
-        return tuple(x)
+        return tuple([ensure_tuple_or_str(elem) for elem in x])
 
 def type_to_str(t):
     t = ensure_tuple_or_str(t)
-    if t in PRIMITIVES:
+    if isinstance(t, STRING_TYPES):
         return t
     else:
         s = t[0] + '<'
@@ -130,22 +135,34 @@ class CyclusAgent(Directive):
             self.lines.append(':{0}: {1}'.format(key, val))
         self.lines.append('')
 
-    skipstatevar = {'type', 'index', 'shape', 'doc', 'tooltip', 'default'}
+    skipstatevar = {'type', 'index', 'shape', 'doc', 'tooltip', 'default', None}
 
     def append_statevars(self):
         vars = OrderedDict(sorted(self.annotations.get('vars', {}).items(), 
-                           key=lambda x: x[1]['index']))
+                           key=lambda x: x[1]['index'] if not isinstance(x[1], STRING_TYPES) else 0))
         if len(vars) == 0:
             return
         lines = self.lines
         lines += ['', '**State Variables:**', '']
         for name, info in vars.items():
+            if isinstance(info, STRING_TYPES):
+                # must be an alias entry - skip it
+                continue
+            elif contains_resbuf(type_to_str(info['type'])):
+                # resbufs are not directly user accessible
+                continue
+            elif 'internal' in info:
+                continue
+
+            alias = info.get('alias', name)
+            name = alias if isinstance(alias, STRING_TYPES) else alias[0]
+
             # add name
             n = ":{0}: ``{1}``" .format(name, type_to_str(info['type']))
-            if 'shape' in info:
-                n += ', shape={0}'.format(info['shape'])
             if 'default' in info:
                 n += ', default={0}'.format(info['default'])
+            if 'shape' in info:
+                n += ', shape={0}'.format(info['shape'])
             lines += [n, '']
 
             # add docs

--- a/source/user/cycamoreagents.rst
+++ b/source/user/cycamoreagents.rst
@@ -1,5 +1,6 @@
 Cycamore Archetypes
 ====================
+
 This is a collection of archetypes found in the ``cycamore`` module that comes with 
 cycamore itself.
 

--- a/source/user/cycamoreagents.rst
+++ b/source/user/cycamoreagents.rst
@@ -8,13 +8,17 @@ cycamore itself.
 
 .. cyclus-agent:: :cycamore:Sink
 
+.. cyclus-agent:: :cycamore:Enrichment
+
+.. cyclus-agent:: :cycamore:Reactor
+
+.. cyclus-agent:: :cycamore:Separations
+
+.. cyclus-agent:: :cycamore:FuelFab
+
 .. cyclus-agent:: :cycamore:DeployInst
 
 .. cyclus-agent:: :cycamore:ManagerInst
 
 .. cyclus-agent:: :cycamore:GrowthRegion
-
-.. cyclus-agent:: :cycamore:EnrichmentFacility
-
-.. cyclus-agent:: :cycamore:BatchReactor
     :no-sep:


### PR DESCRIPTION
Note that this shouldn't be merged until after Reactor, FuelFab, Separations, Enrichment archetypes are merged in.

* Fix side bar links to be local to website so they work correctly in preview modes.

* Fixed cyclusagent directive to handle alias properly and also the deal with the new recursive alias
specification.  Now support recursive container types correctly. Support for
'internal' state var annotation that indicates a var is not for user
consumption. Fixed a couple other bugs.

* adjustements to show new cycamore archetype docs in user guide