### PR TITLE
Make archetype docs even prettier

### DIFF
--- a/source/cyclusagent.py
+++ b/source/cyclusagent.py
@@ -261,18 +261,24 @@ class CyclusAgent(Directive):
         if 'doc' in self.annotations:
             self.lines += self.annotations['doc'].splitlines()
         self.lines.append('')
+
+    def append_otherinfo(self):
+        header = 'Other Info'
+        self.lines += [header, ';' * len(header), '']
+
         for key in ('entity', 'parents', 'all_parents'):
             val = self.annotations.get(key, None)
             if val is None:
                 continue
-            self.lines.append(':{0}: {1}'.format(key, nicestr(val)))
+            self.lines.append('* **{0}**: {1}'.format(key, nicestr(val)))
         for key, val in sorted(self.annotations.items()):
             if key in self.skipdoc:
                 continue
-            self.lines.append(':{0}: {1}'.format(key, val))
+            self.lines.append('* **{0}**: {1}'.format(key, val))
         self.lines.append('')
 
-    skipstatevar = {'type', 'index', 'shape', 'doc', 'tooltip', 'default', None}
+    skipstatevar = {'type', 'index', 'shape', 'doc', 'tooltip', 'default',
+                    'units', None}
 
     def append_statevars(self):
         vars = OrderedDict(sorted(self.annotations.get('vars', {}).items(), 
@@ -280,7 +286,9 @@ class CyclusAgent(Directive):
         if len(vars) == 0:
             return
         lines = self.lines
-        lines += ['', '**State Variables:**', '']
+        header = 'State Variables'
+        lines += [header, ';' * len(header), '']
+
         for name, info in vars.items():
             if isinstance(info, STRING_TYPES):
                 # must be an alias entry - skip it
@@ -295,7 +303,12 @@ class CyclusAgent(Directive):
             name = alias if isinstance(alias, STRING_TYPES) else alias[0]
 
             # add name
-            n = ":{0}: ``{1}``" .format(name, type_to_str(info['type']))
+            ts = type_to_str(info['type'])
+            if 'units' in info:
+                n = ":{0}: ``{1}`` {2} " .format(name, ts, info['units'])
+            else:
+                n = ":{0}: ``{1}``" .format(name, ts)
+
             if 'default' in info:
                 n += ', optional ('
                 if info['type'] == 'std::string':
@@ -309,12 +322,12 @@ class CyclusAgent(Directive):
 
             # add docs
             ind = " " * 4
-            if 'tooltip' in info:
-                self.lines += [ind + '*' + info['tooltip'] + '*', '']
             if 'doc' in info:
                 doc = ind + info['doc'].replace('\n', '\n'+ind) 
                 lines += doc.splitlines()
                 lines.append('')
+            elif 'tooltip' in info:
+                self.lines += [ind + '*' + info['tooltip'] + '*', '']
 
             t = info['type']
             uitype = info.get('uitype', None)
@@ -343,8 +356,11 @@ class CyclusAgent(Directive):
 
 
     def append_schema(self):
+        header = 'XML Input Schema'
+        self.lines += [header, ';' * len(header), '']
+
         lines = self.lines
-        lines += ['', '**Schema:**', '', '.. code-block:: xml', '']
+        lines += ['', '.. code-block:: xml', '']
         ind = " " * 4
         s = ind + self.schema.replace('\n', '\n' + ind) + '\n'
         lines += s.splitlines()
@@ -375,6 +391,7 @@ class CyclusAgent(Directive):
         self.append_name()
         self.append_doc()
         self.append_statevars()
+        self.append_otherinfo()
         self.append_schema()
         self.append_sep()
 


### PR DESCRIPTION
* Use subheadings for State variables, and schema sections rather than just
  bold text on its own line.

* Move misc annotations into their own "Other Info" subheading section rather
  than just below the doc paragraph.  This section is placed below everything
  except the schema

* Move state variable units annotation onto the same line as state var header
  right next to the variable type - e.g. :[statevarname]: ``double`` kg.

* Don't print the tooltip if there is a doc annotation.  tooltip is a fallback
  only if necessary.  This eliminates redundant/annoying info and makes the docs
  much nicer to look at.