### PR TITLE
First attempt at page linking to projects using Cyculs

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -56,6 +56,7 @@ Learn More
     user/index
     arche/index
     kernel/index
+    projects/index
     cep/cep0
     previous/index
     cite/index

--- a/source/projects/index.rst
+++ b/source/projects/index.rst
@@ -1,0 +1,13 @@
+|Cyclus|-Related Projects
+==========================================
+
+This is a partial list of projects that are known to be using |Cyclus| as part
+of their research.
+
+* Consortium for Verification Technology (U. Wisconsin-Madison with U. Michigan)
+* Bright-lite (U. Texas-Austin)
+* ???? (U. Tennessee)
+* Fuel Cycle Options Transition Analysis (LLNL, U. California-Berkeley, U. Wisconsin)
+* Fuel Cycle Optimization (U. Wisconain-Madison)
+
+


### PR DESCRIPTION
This probably isn't quite ready.  Minimally we need to confirm titles for all the projects, and then we can push without links. 

Ultimately, it would be good to include the following for each project:
* logo
* correct title with link
* 1-3 sentence description

These can be PR'd by the project owners.