### PR TITLE
docker build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ help:
 	@echo "  linkcheck  to check all external links for integrity"
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
+html-docker gh-preview-docker:
+	docker run -w /cyclus.github.com -v $(PWD):/cyclus.github.com cyclus/fuelcycle.org-deps make gh-preview
+
 gh-clean gh-revert clean:
 	-rm -rf $(BUILDDIR)
 

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,11 @@ branch, you may always run::
 
     make html
 
+Or if you have docker, you can forget about the other dependencies and just
+run::
+
+    make html-docker
+
 Best practice workflow for contributing to site changes
 --------------------------------------------------------
 
@@ -70,7 +75,13 @@ Best practice workflow for contributing to site changes
 
    This will build a version of the site in the `gh-build` directory of
    your branch, `add_some_info`.  You can load it directly in a local
-   browser.
+   browser.  Or if you have docker installed, you can optionally use the
+   docker preview target:
+
+   ``make gh-preview-docker``
+
+   to build the website inside a docker container with all the correct
+   dependencies and configuration taken care of automagically.
 
 6. Repeat steps 4-5 until satisfied.
 

--- a/docker/README.rst
+++ b/docker/README.rst
@@ -1,0 +1,8 @@
+
+``fuelcycle.org-deps`` contains a dockerfile with all dependencies for
+building cymetric.  This is used by the docker based build targets added to
+the makefile.  This image will need to be updated and repushed to docker hub
+periodically when dependencies for the website need updating.  Particularly,
+this image will need to be rebuilt whenever there is a new release of
+cyclus+cycamore.
+

--- a/docker/fuelcycle.org-deps/Dockerfile
+++ b/docker/fuelcycle.org-deps/Dockerfile
@@ -1,0 +1,12 @@
+
+FROM cyclus/cycamore
+
+RUN apt-get install -y --force-yes python3-pip
+RUN pip3 install sphinx sphinxcontrib-bibtex cloud-sptheme
+
+WORKDIR /
+RUN git clone https://github.com/cyclus/cymetric
+WORKDIR /cymetric
+RUN python setup.py install
+WORKDIR /
+


### PR DESCRIPTION
This adds a dockerfile that is based on cyclus/cycamore that adds other deps necessary for a site build.  The image from this dockerfile will need to be pushed up to docker hub when we get cymetric fixed.  This adds 2 targets html-docker and gh-preview-docker to the makefile that builds the site inside the fuelcycle.org-deps image and leaves the built site files in the host computer's working directory exactly as if they had run the make html command like normal without docker.