### PR TITLE
Add details for improving docker usage experience:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,8 @@ help:
 	@echo "  gh-publish-only   to push from source branch to master branch, assuming already built"
 	@echo "  docker-html       to use docker to build HTML in directory $BUILDDIR for testing"
 	@echo "  docker-gh-publish to use docker to build final version and push from source branch to master branch"
-	@echo "  serve             serve built html files using Python's SimpleHTTPServer"
+	@echo "  serve             build+serve html files using Python's SimpleHTTPServer"
+	@echo "  serve-only        serve pre-built html files using Python's SimpleHTTPServer"
 	@echo "  dirhtml           to make HTML files named index.html in directories"
 	@echo "  singlehtml        to make a single large HTML file"
 	@echo "  pickle            to make pickle files"
@@ -89,8 +90,10 @@ docker-gh-publish:
 	make gh-publish-only
 
 serve: html
-	cd $(BUILDDIR)
-	python -m SimpleHTTPServer
+	cd $(BUILDDIR) && python -m http.server
+
+serve-only:
+	cd $(BUILDDIR) && python -m http.server
 
 htmlclean cleanhtml: clean html
 

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,12 @@ branch, you may always run::
 Or if you have docker, you can forget about the other dependencies and just
 run::
 
-    make html-docker
+    make docker-html
+
+
+There are docker targets in the makefile for doing everything related to the
+site - building, previewing, and publishing.  See the ``Docker`` section below
+for more details.
 
 Best practice workflow for contributing to site changes
 --------------------------------------------------------
@@ -136,6 +141,28 @@ Best practice for managing a pull request
 7. Republish the pages with the `gh-publish` target.
 
    ``make gh-publish``
+
+Docker
+-------
+
+The ``make docker-...`` targets require the cyclus/fuelcycle.org-deps docker image
+which can be retrieved/updated by running::
+
+    docker pull cyclus/fuelcycle.org-deps
+
+Occasionally (i.e. for a Cyclus release) the image will need to be updated.
+This can be done by::
+
+    cd docker/fuelcycle.org-deps
+
+    # update the image the fuelcycle.org image depends on
+    docker pull cyclus/cymetric   
+
+    # rebuild the image
+    docker build -t cyclus/fuelcycle.org-deps . 
+
+    # push the new image to docker-hub
+    docker push cyclus/fuelcycle.org-deps
 
 .. _Sphinx: http://sphinx-doc.org/
 .. _sphinxcontrib-bibtex: http://sphinxcontrib-bibtex.readthedocs.org/en/latest/index.html


### PR DESCRIPTION
* Add more instructions to readme for updating website deps image

* Modify/add "serve" make targets to support python3 in addition to allowing
  servince pre-built files (e.g. to enable serving a docker build)