### PR TITLE
Clean install docs

### DIFF
--- a/source/arche/index.rst
+++ b/source/arche/index.rst
@@ -37,8 +37,10 @@ To get started please follow the instructions in :doc:`hello_world`.
 Installation
 -------------
 
-Install Cyclus via the instructions on `Github
-<https://github.com/cyclus/cyclus>`_.
+.. toctree::
+    :maxdepth: 1
+
+    ../user/install
 
 Hello World
 -----------

--- a/source/atemplates/layout.html
+++ b/source/atemplates/layout.html
@@ -4,9 +4,12 @@
   <div class="sphinxlocaltoc">
   <h3>{{ _('Useful Pages') }}</h3>
     <ul><li><ul>
+    <li><a href="/user/install.html">Install Cyclus</a></li>
     <li><a href="/user/index.html">User Guide</a></li>
+    <li><a href="/user/tutorial/index.html">User Tutorial</a></li>
     <li><a href="/arche/index.html">Archetype Developer Guide</a></li>
-    <li><a href="http://fuelcycle.org/cyclus/api/">Cyclus API Documentation</a></li>
+    <li><a href="/arche/tutorial/index.html">Archetype Developer Tutorial</a></li>
+     <li><a href="http://fuelcycle.org/cyclus/api/">Cyclus API Documentation</a></li>
     <li><a href="http://fuelcycle.org/cycamore/api/">Cycamore API Documentation</a></li>
     <li><a href="/basics/glossary.html">Glossary</a></li>
     <li><a href="mailto:cyclus-users+subscribe@googlegroups.com?subject=Subscribe&body=Send this message to subscribe to the list">Join</a> the 

--- a/source/index.rst
+++ b/source/index.rst
@@ -27,11 +27,13 @@ developers and encourages them to join a vibrant community in an
 :doc:`expanding ecosystem <basics/ecosystem>`.  Users and developers are
 always welcome and encouraged to use or contribute to the |cyclus| project. 
 
-The |Cyclus| project repository is located at http://github.com/cyclus/cyclus.
+The |Cyclus| project repository is located at http://github.com/cyclus/cyclus
 
-Want to try out |Cyclus|?  Head to the :doc:`Quick Start <user/install>`. 
+Project repository is located at http://github.com/cyclus/cyclus
 
-project repository is located at http://github.com/cyclus/cyclus.
+Quick Start
+-----------
+:doc:`Install Cyclus <user/install>`
 
 News
 -----

--- a/source/index.rst
+++ b/source/index.rst
@@ -29,6 +29,10 @@ always welcome and encouraged to use or contribute to the |cyclus| project.
 
 The |Cyclus| project repository is located at http://github.com/cyclus/cyclus.
 
+Want to try out |Cyclus|?  Head to the :doc:`Quick Start <user/install>`. 
+
+project repository is located at http://github.com/cyclus/cyclus.
+
 News
 -----
 

--- a/source/user/index.rst
+++ b/source/user/index.rst
@@ -5,20 +5,17 @@
 
 This guide covers the basics of installation, creating simulation input files,
 and running them.  If you haven't already, you should take a look at
-:ref:`Fundemental Concepts in Cyclus <basics-concepts>`. After that you can install |cyclus|:
+:ref:`Fundamental Concepts in Cyclus <basics-concepts>`.
+     
 
 Installing |Cyclus|
 --------------------
 
-* The easiest way to install |Cyclus| on a new system is to :doc:`install using Conda <install>`.
-* If you are on an unsupported system (e.g., Windows), try the :doc:`Cyclus virtual box <virtualbox>`.
-* More adventurous users may want to try :doc:`getting and building Cyclus from source </kernel/build_from_source>`.
-
 .. toctree::
-    :hidden:
+   :maxdepth: 1
 
-    install
-    virtualbox
+   install
+
 
 Writing Input Files
 ---------------------

--- a/source/user/install.rst
+++ b/source/user/install.rst
@@ -1,91 +1,45 @@
-Installing |Cyclus| with Conda
+Getting Started with |Cyclus| 
 ==============================
-Conda is a cross platform, user space package manager aimed at simplifying the 
-installation of open source software.  The |cyclus| project uses conda to distribute 
-pre-built cyclus and cycamore binaries.
+|Cyclus| can be run on Linux or Mac OSX. It cannot be run on Windows except by using Linux in a Virtualbox.
 
-Fresh Install
--------------
-If you are new to conda or do not have conda already installed on your system, 
-please follow these steps to install |cyclus|.
-Basic installation instructions for Conda can be found 
-`here <http://docs.continuum.io/anaconda/install.html>`_. 
+To model fuel cycles, you will need to install two things: first the main codebase (called  :doc:`Cyclus <../basics/index>`), and then a set of fuel-cycle specific archetypes (called :doc:`Cycamore <index>`).  
 
-1. Download and Install Miniconda
 
-    * Go to the `miniconda downloads page <http://conda.pydata.org/miniconda.html>`_
-      and get the version approriate to your system.
-    * Install this to the ``~/miniconda`` directory.  For example, you would 
-      use a command similar the following:
+1. Install |Cyclus| and Cycamore
+---------------------------------
+The following methods of installation are listed in order of increasing sophistication. Choose the option that best fits your needs.
 
-      .. code-block:: bash 
+*  :doc:`Cyclist and the Cloud <tutorial/install_launch_cyclist>`: For users who want a graphical user interface to build or analyze simulations or do not want to run simulations directly on their machine. (After installation, skip to Step 4 "Try a Tutorial").
 
-          $ bash Miniconda-3.5.2-Linux-x86_64.sh -b -p ~/miniconda
+* :doc:`Install as a Binary <install_binary>`: (via Debian or Conda) For users who want to run simulations directly on their machine (without internet).
 
-    * Finally, add the ``~/miniconda/bin`` directory to your ``PATH`` either 
-      in your current environment or in your ``.bashrc`` or both.
+* :doc:`Virtualbox <virtualbox>`: For Windows users. Requires familiarity with Linux.
 
-      .. code-block:: bash 
+* :doc:`Install Stable From Source <install_tarball>`: (via Tarball) For users who want to modify existing archetypes (aka developers).
 
-          $ export PATH="${HOME}/miniconda/bin:${PATH}"
+* :doc:`Install Develop from Source <../kernel/build_from_source>`: (via Repository) For developers or users who require the bleeding edge version of |Cyclus|.
 
-2. Configure conda to look for |cyclus|
+2. Run Unit Tests
+-----------------
+(Cyclist users skip this step). Unit tests will verify that the installation was successful. They should report that all tests have passed (or been disabled).
 
-    * Download this :download:`condarc` file and save it as ``~/.condarc``.  If 
-      you'd prefer to do this from the command line, type:
+.. code-block:: bash
 
-      .. code-block:: bash 
+   $ cyclus_unit_tests
+   $ cycamore_unit_tests
 
-          $ curl -L http://fuelcycle.org/_downloads/condarc >> ~/.condarc
+   
+3. Run Cyclus with a Sample XML File
+------------------------------------
+(Cyclist users skip this step). Try running |Cyclus| for yourself. The result will be a :doc:`database <dbdoc>` named cyclus.sqlite.  Load the sqlite file into Cyclist to visualize data, or use your favorite sqlite browser to peruse.
 
-3. Install |Cyclus| and Cycamore
+.. code-block:: bash
 
-    * Now that conda is installed and ready, installing |Cyclus| is as simple as:
+   $ cyclus ~/path/to/cycamore/input/recycle.xml
 
-      .. code-block:: bash 
-    
-          $ conda install cycamore --yes
+4. Try a Tutorial!
+------------------
+To become familiar with the capabilities of |Cyclus|, read the :doc:`User's Guide<index>` and possibly the :doc:`Archetype Developer's Guide <../arche/index>`, or  work your way through the tutorials.
 
-      Note that installing cycamore will also install cyclus since cyclus is one 
-      of cycamore's dependencies.
-
-4. Install Cyclist (optional)
-
-    * Now that cyclus is installed and ready, installing the graphical user interface is 
-      simple as:
-
-      .. code-block:: bash 
-    
-          $ conda install cyclist --yes
-
-And that is it! 
-
-Already Have Conda?
--------------------
-If you already have conda installed, installing |Cyclus| is even easier.
-You simply need to make sure that the |Cyclus| binstar organization is part of 
-your channels.  Please edit the ``channels`` section of your :file:`~/.condarc`
-to include the URL ``https://conda.binstar.org/cyclus``.  For example, 
-
-.. code-block:: yaml
-
-	channels:
-	  - https://conda.binstar.org/cyclus 
-	  - defaults
-
-Once this is done, install |Cyclus| with the following comand.
-
-.. code-block:: bash 
-    
-    $ conda install cycamore --yes
-
-Note that installing cycamore will also install cyclus since cyclus is one 
-of cycamore's dependencies.  Furthermore, you may also optionally install Cyclist,
-the graphical user interface tool for cyclus databases. This can be done 
-with the following:
-
-.. code-block:: bash 
-    
-    $ conda install cyclist --yes
-
-Happy simulating!
+* :doc:`Cyclus User Tutorial <tutorial/index>`
+* :doc:`Archetype Developer Tutorial  <../arche/tutorial/index>`

--- a/source/user/install_binary.rst
+++ b/source/user/install_binary.rst
@@ -1,0 +1,91 @@
+Installing |Cyclus| with Conda
+==============================
+Conda is a cross platform, user space package manager aimed at simplifying the 
+installation of open source software.  The |cyclus| project uses conda to distribute 
+pre-built cyclus and cycamore binaries.
+
+Fresh Install
+-------------
+If you are new to conda or do not have conda already installed on your system, 
+please follow these steps to install |cyclus|.
+Basic installation instructions for Conda can be found 
+`here <http://docs.continuum.io/anaconda/install.html>`_. 
+
+1. Download and Install Miniconda
+
+    * Go to the `miniconda downloads page <http://conda.pydata.org/miniconda.html>`_
+      and get the version approriate to your system.
+    * Install this to the ``~/miniconda`` directory.  For example, you would 
+      use a command similar the following:
+
+      .. code-block:: bash 
+
+          $ bash Miniconda-3.5.2-Linux-x86_64.sh -b -p ~/miniconda
+
+    * Finally, add the ``~/miniconda/bin`` directory to your ``PATH`` either 
+      in your current environment or in your ``.bashrc`` or both.
+
+      .. code-block:: bash 
+
+          $ export PATH="${HOME}/miniconda/bin:${PATH}"
+
+2. Configure conda to look for |cyclus|
+
+    * Download this :download:`condarc` file and save it as ``~/.condarc``.  If 
+      you'd prefer to do this from the command line, type:
+
+      .. code-block:: bash 
+
+          $ curl -L http://fuelcycle.org/_downloads/condarc >> ~/.condarc
+
+3. Install |Cyclus| and Cycamore
+
+    * Now that conda is installed and ready, installing |Cyclus| is as simple as:
+
+      .. code-block:: bash 
+    
+          $ conda install cycamore --yes
+
+      Note that installing cycamore will also install cyclus since cyclus is one 
+      of cycamore's dependencies.
+
+4. Install Cyclist (optional)
+
+    * Now that cyclus is installed and ready, installing the graphical user interface is 
+      simple as:
+
+      .. code-block:: bash 
+    
+          $ conda install cyclist --yes
+
+And that is it! 
+
+Already Have Conda?
+-------------------
+If you already have conda installed, installing |Cyclus| is even easier.
+You simply need to make sure that the |Cyclus| binstar organization is part of 
+your channels.  Please edit the ``channels`` section of your :file:`~/.condarc`
+to include the URL ``https://conda.binstar.org/cyclus``.  For example, 
+
+.. code-block:: yaml
+
+	channels:
+	  - https://conda.binstar.org/cyclus 
+	  - defaults
+
+Once this is done, install |Cyclus| with the following comand.
+
+.. code-block:: bash 
+    
+    $ conda install cycamore --yes
+
+Note that installing cycamore will also install cyclus since cyclus is one 
+of cycamore's dependencies.  Furthermore, you may also optionally install Cyclist,
+the graphical user interface tool for cyclus databases. This can be done 
+with the following:
+
+.. code-block:: bash 
+    
+    $ conda install cyclist --yes
+
+Happy simulating!

--- a/source/user/install_tarball.rst
+++ b/source/user/install_tarball.rst
@@ -1,0 +1,2 @@
+Installing |Cyclus| using a Tarball
+====================================


### PR DESCRIPTION
Started changes outlined in Issue #198. I have worked on #1,#2 from that list, with outstanding tasks listed below.  #3 has not been addressed with this PR.

To Do:
- user/tutorial/install_launch_cyclist.rst - update installers (Linux, Mac, Windows)
- user/install_binary.rst - update instructions to include install from Debian binary. Possibly split out basic Conda install instructions into a new file
- user/virtualbox.rst - update cyclus ova file
- user/install_tarball.rst - build this page with instructions, build tarball to link to (Linux & Mac)
- kernel/install_from_source - revamp this page with Baptiste's detailed installation instructions from the README (Linux & Mac)