### PR TITLE
Release Management Changes to CEP3

### DIFF
--- a/source/cep/cep-0003-1.svg
+++ b/source/cep/cep-0003-1.svg
@@ -9,11 +9,11 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="234.58302"
-   height="234.35539"
+   width="250.22189"
+   height="249.97908"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
+   inkscape:version="0.92.1 r15371"
    sodipodi:docname="cep-0003-1.svg">
   <defs
      id="defs4" />
@@ -30,11 +30,11 @@
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="1438"
-     inkscape:window-height="868"
+     inkscape:window-width="3838"
+     inkscape:window-height="2082"
      inkscape:window-x="0"
-     inkscape:window-y="30"
-     inkscape:window-maximized="0"
+     inkscape:window-y="38"
+     inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
@@ -55,72 +55,58 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(-27.274117,-57.361923)">
-    <path
-       sodipodi:type="arc"
-       style="opacity:0.15637859;fill:#a02c2c;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     transform="translate(-29.092391,-61.186051)">
+    <circle
+       style="opacity:0.15637859;fill:#a02c2c;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.06666672"
        id="path2987"
-       sodipodi:cx="33.335033"
-       sodipodi:cy="47.260399"
-       sodipodi:rx="117.1777"
-       sodipodi:ry="117.1777"
-       d="m 150.51273,47.260399 c 0,64.715451 -52.462242,117.177701 -117.177697,117.177701 -64.715454,0 -117.177696,-52.46225 -117.177696,-117.177701 0,-64.715455 52.462242,-117.177696 117.177696,-117.177696 64.715455,0 117.177697,52.462241 117.177697,117.177696 z"
-       transform="translate(111.11678,127.27922)" />
+       cx="154.08194"
+       cy="186.1756"
+       r="124.98954" />
     <text
        xml:space="preserve"
-       style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:FreeSerif;-inkscape-font-specification:FreeSerif"
-       x="89.285713"
-       y="115.50504"
-       id="text2991"
-       sodipodi:linespacing="125%"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.80000019px;line-height:0%;font-family:FreeSerif;-inkscape-font-specification:FreeSerif;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.06666672"
+       x="95.238091"
+       y="123.20538"
+       id="text2991"><tspan
          sodipodi:role="line"
          id="tspan2993"
-         x="89.285713"
-         y="115.50504"
-         style="font-size:16px">develop</tspan></text>
-    <path
-       sodipodi:type="arc"
-       style="opacity:0.15637859;fill:#87cdde;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="95.238091"
+         y="123.20538"
+         style="font-size:17.06666756px;line-height:1.25;stroke-width:1.06666672">topical</tspan></text>
+    <circle
+       style="opacity:0.15637859;fill:#87cdde;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.06666672"
        id="path2999"
-       sodipodi:cx="220.89285"
-       sodipodi:cy="203.61218"
-       sodipodi:rx="74.10714"
-       sodipodi:ry="74.10714"
-       d="m 294.99999,203.61218 c 0,40.92825 -33.17889,74.10714 -74.10714,74.10714 -40.92824,0 -74.10714,-33.17889 -74.10714,-74.10714 0,-40.92824 33.1789,-74.10714 74.10714,-74.10714 40.92825,0 74.10714,33.1789 74.10714,74.10714 z"
-       transform="translate(-33.928571,-31.071429)" />
+       cx="199.42857"
+       cy="184.04347"
+       r="79.047615" />
     <text
        xml:space="preserve"
-       style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:FreeSerif;-inkscape-font-specification:FreeSerif"
-       x="160.79428"
-       y="150.94731"
-       id="text2991-3"
-       sodipodi:linespacing="125%"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.80000019px;line-height:0%;font-family:FreeSerif;-inkscape-font-specification:FreeSerif;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.06666672"
+       x="171.5139"
+       y="161.01047"
+       id="text2991-3"><tspan
          sodipodi:role="line"
          id="tspan2993-6"
-         x="160.79428"
-         y="150.94731"
-         style="font-size:16px">v0.2-release</tspan></text>
-    <path
-       sodipodi:type="arc"
-       style="opacity:0.15637859;fill:#ff5555;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         x="171.5139"
+         y="161.01047"
+         style="font-size:17.06666756px;line-height:1.25;stroke-width:1.06666672">v4.2-release</tspan></text>
+    <ellipse
+       style="opacity:0.15637859;fill:#ff5555;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.97194982"
        id="path3024"
-       sodipodi:cx="225"
-       sodipodi:cy="199.86218"
-       sodipodi:rx="38.214287"
-       sodipodi:ry="38.214287"
-       d="m 263.21429,199.86218 c 0,21.10517 -17.10912,38.21429 -38.21429,38.21429 -21.10517,0 -38.21429,-17.10912 -38.21429,-38.21429 0,-21.10517 17.10912,-38.21428 38.21429,-38.21428 21.10517,0 38.21429,17.10911 38.21429,38.21428 z"
-       transform="matrix(0.91588785,0,0,0.90654206,20.782376,-4.8927208)" />
+       cx="241.98096"
+       cy="188.04347"
+       rx="37.333336"
+       ry="36.952381" />
     <text
        xml:space="preserve"
-       style="font-size:16px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:center;line-height:125%;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;font-family:FreeSerif;-inkscape-font-specification:FreeSerif"
-       x="226.32915"
-       y="178.57132"
-       id="text2991-3-7"
-       sodipodi:linespacing="125%"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12.80000019px;line-height:0%;font-family:FreeSerif;-inkscape-font-specification:FreeSerif;text-align:center;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.06666672"
+       x="241.41776"
+       y="190.47607"
+       id="text2991-3-7"><tspan
          sodipodi:role="line"
          id="tspan2993-6-7"
-         x="226.32915"
-         y="178.57132"
-         style="font-size:16px">master</tspan></text>
+         x="241.41776"
+         y="190.47607"
+         style="font-size:17.06666756px;line-height:1.25;stroke-width:1.06666672">master</tspan></text>
   </g>
 </svg>

--- a/source/cep/cep3.rst
+++ b/source/cep/cep3.rst
@@ -3,7 +3,7 @@ CEP 3 - |Cyclus| Release Procedure
 
 :CEP: 3
 :Title: |Cyclus| Release Procedure
-:Last-Modified: 2017-02-13
+:Last-Modified: 2017-09-01
 :Author: Anthony Scopatz and Matthew Gidden and Baptiste Mouginot
 :Status: Accepted
 :Type: Process
@@ -11,39 +11,37 @@ CEP 3 - |Cyclus| Release Procedure
 
 Abstract
 ========
-
-The purpose of this document is to act as a guideline and checklist for how 
+The purpose of this document is to act as a guideline and checklist for how
 to release the |cyclus| core code base and the supported projects in the ecosystem.
 
 The |Cyclus| Ecosystem
 ======================
+The very first thing to do when preparing for an upcoming release is to elect
+a release manager.  This person has the special responsibility of making sure
+all of the following tasks are implemented.  Therefore, their judgment for the
+placement of issues and code stability must be adhered to.
 
-The very first thing to do when preparing for an upcoming release is to elect 
-a release manager.  This person has the special responsibility of making sure 
-all of the following tasks are implemented.  Therefore, their judgment for the 
-placement of issues and code stability must be adhered to.  
-
-The |cyclus| ecosystem has a few projects which are all released together. 
-(This may change in the future a development diverges and the core becomes more 
+The |cyclus| ecosystem has a few projects which are all released together.
+(This may change in the future a development diverges and the core becomes more
 stable.)  The projects that are under the release manager's purview are:
 
-* `Cyclus`_ 
-* `Cycamore`_ 
+* `Cyclus`_
+* `Cycamore`_
 * `Cymetric`_
 
 The projects which are not yet under the release managers purview are:
 
-* `Cyclist`_ 
+* `Rickshaw`_
+* `CyclusJS`_
 
 Release Candidates (Tags & Branches)
 ====================================
-
 At the beginning of a release, a special branch for *each* project should be
-made off of ``develop`` named ``vX.X.X-release``. Note the *v* at the beginning. Each
+made off of ``master`` named ``vX.X.X-release``. Note the *v* at the beginning. Each
 project should have the initial version of of it's release branch *tagged* as
 ``X.X.X-rc1``, the first release candidate.
 
-.. note:: 
+.. note::
 
     To distingush them, branch names have a ``v`` prefix (``vX.X.X-release``)
     while tag names lack this prefix (``X.X.X-rcX``).
@@ -54,13 +52,13 @@ the project should be encouraged to test them out in order to bugs/other issues.
 
 Any required changes must be pull requested from a topical branch into the
 *release* branch.  After this has been accepted, the topical branch must be
-merged with ``develop`` as well. The release branch is there so that development
-can continue on the ``develop`` branch while the release candidates (rc) are out
+merged with ``master`` as well. The release branch is there so that development
+can continue on the ``master`` branch while the release candidates (rc) are out
 and under review.  This is because otherwise any new developments would have to
-wait until post-release to be merged into ``develop`` to prevent them from
+wait until post-release to be merged into ``master`` to prevent them from
 accidentally getting released early.
 
-Everything that is in the release branch must also be part of ``develop``.
+Everything that is in the release branch must also be part of ``master``.
 Graphically,
 
 .. figure:: cep-0003-1.svg
@@ -68,13 +66,13 @@ Graphically,
 
     **Figure 1:** Branch hierarchy under release.
 
-.. note:: 
+.. note::
 
     Any commits merged into the release branch must *also* be merged into
-    ``develop``. It is common practice for the release manager to request the
-    reviewer pull requests to merge the subject topical branch into ``develop``
+    ``master``. It is common practice for the release manager to request the
+    reviewer pull requests to merge the topical branch into ``master``
     as well. However, it is the ultimate release manager's responsibility to
-    make sure ``develop`` is kept up to date with the ``release`` branch.
+    make sure ``master`` is kept up to date with the ``release`` branch.
 
 If changes are made to the release branch, a new candidate must be issued after
 *2 - 5 days*. Every time a new release candidate comes out the ``vX.X.X-release``
@@ -112,13 +110,13 @@ Release Candidate Process
 
 #. Finish the release candidate process
 
-    - make sure all commits in the ``release`` branch also are in ``develop``
+    - make sure all commits in the ``release`` branch also are in ``master``
 
 Release Process
 ---------------
 
 #. Make sure every local |cyclus| project repository is up to date with its
-   ``master``, ``develop``, and ``vX.X.X-release`` branches on ``upstream``.
+   ``master``, and ``vX.X.X-release`` branches on ``upstream``.
 
 #. Bump the version in ``cyclus/src/version.h.in``,
    ``cycamore/src/cycamore_version.h.in``, and
@@ -126,7 +124,7 @@ Release Process
 
 #. Perform maintenance tasks for all projects. The maintenance depends on `PyNE
    <https://github.com/pyne/pyne.git>`_ and Doxygen.
-    
+
     - they are described in detail below, *but* the ``maintenence.sh`` utility
       in ``release/utils`` will do this automatically for you
 
@@ -139,22 +137,22 @@ Release Process
       $ export CYCAMORE_DIR=/path/to/cycamore
       $ ./maintenence.sh -r -v X.X.X # X.X.X is *this* version
 
-    .. note:: 
+    .. note::
 
           If maintenance script fails because of an ABI failure that is caused by
           a compiler update (or other similar change caused by reasons other
           than code changes), you might want to accept them and procceed with the
           release with those. To do so you need to generate the new symbols and
           commit them:
-          
+
           #. First make sure those changes can be ignored by emailing for
              discussion/approval the dev-list
-          
+
           #. if the dev-list agrees to those changes, update the symbols and
              commit the new one:
 
           .. code-block:: bash
-            
+
                 $ cd $CYCLUS_DIR/release
                 $ ./smbchk.py --update -t X.X.X # X.X.X is *this* version
                 $ git add symbols.json
@@ -169,14 +167,14 @@ Release Process
       $ git checkout vX.X.X-release
       $ git commit -am "final release commit after maintenence"
 
-#. Update all develop branches.
+#. Update all master branches.
 
     .. code-block:: bash
 
       $ cd /path/to/project
-      $ git checkout develop
+      $ git checkout master
       $ git merge --no-ff vX.X.X-release
-      $ git push upstream develop
+      $ git push upstream master
 
 #. *Locally* tag the repository for *each* of the projects.
 
@@ -230,7 +228,7 @@ Release Process
 
 
 #. Update Conda-forge
- 
+
     - For each project, find the corresponding feedstock repository in the
       conda-forge organization on github. For example, cyclus' feedstock is at
       https://github.com/conda-forge/cyclus-feedstock
@@ -238,7 +236,7 @@ Release Process
     - In each project's feedstok, open up a PR which updates the
       `recipe/meta.yaml` file with the new version number and the new SHA-256
       value of the new version's tarball. See conda-forge documentation for more
-      or ask the feedstock maintainers for help. 
+      or ask the feedstock maintainers for help.
 
     - Note that each feedstock must be accepted and the package uploaded to
       anaconda.org (automatic) prior to accepting updates for the next feedstock
@@ -253,7 +251,7 @@ Release Process
 #. Update website release information.
 
     - on the front page (``source/index.rst``)
-    - DOIs (``source/cite/index.rst``) 
+    - DOIs (``source/cite/index.rst``)
     - release notes (``source/previous/index.rst``), remember both the release
       notes and the zip/tar URLs!
     - layout template (``source/atemplates/layout.html``) of the website
@@ -261,11 +259,11 @@ Release Process
       (``source/user/install_from_tarball.rst``)
 
 
-#. Commit all changes to ``cyclus.github.com`` and ``make gh-publish`` 
+#. Commit all changes to ``cyclus.github.com`` and ``make gh-publish``
 
 #. Send out an email to `cyclus-dev` and `cyclus-users` to announce the release!
 
-   
+
 .. This part has been commented, as it is required for the website, but the
    person in charge of the release might not have the proper access to update the
    Dory worker.  This should be automated when a merge is done on the master branch
@@ -307,14 +305,14 @@ Maintainence Tasks
     will automate this for you. The section remains here for posterity.
 
 Each project may have associate maintenance tasks which may need to be performed
-at least as often as every micro release. 
+at least as often as every micro release.
 
 |Cyclus|
 --------
 
 **Update PyNE:**  PyNE source code is included and shipped as part of |cyclus|. As pyne
 evolves, we'll want to have our version evolve as well. Here are the steps to do so.
-These assume that in your HOME dir there are both the pyne and |cyclus| repos.  Remember 
+These assume that in your HOME dir there are both the pyne and |cyclus| repos.  Remember
 to check in the changes afterwards.
 
 .. code-block:: bash
@@ -322,8 +320,8 @@ to check in the changes afterwards.
     $ cd ~/pyne
     $ ./amalgamate.py -s pyne.cc -i pyne.h
     $ cp pyne.* ~/cyclus/src
-    
-**Update Nuclear Data:** PyNE also provides a nuclear data library generator which we use for 
+
+**Update Nuclear Data:** PyNE also provides a nuclear data library generator which we use for
 our source data.  Occassionally, this needs to be updated as updates to pyne itself come out.
 The command for generating |cyclus| specific nuclear data is as follows:
 
@@ -335,10 +333,10 @@ The command for generating |cyclus| specific nuclear data is as follows:
 
 Once the file is generated it must be put onto rackspace.
 
-**Update Gtest:** We include a copy of the fused Gtest source code within our 
-source tree located in the ``tests/GoogleTest`` directory.  To keep up with 
-Gtest's natural evolution cycle, please download the latest release of Google Tests 
-and follow `the fused source directions here`_.  If we go too long without doing this, 
+**Update Gtest:** We include a copy of the fused Gtest source code within our
+source tree located in the ``tests/GoogleTest`` directory.  To keep up with
+Gtest's natural evolution cycle, please download the latest release of Google Tests
+and follow `the fused source directions here`_.  If we go too long without doing this,
 it could be very painful to update.
 
 **Verify & Update API Stability:** Since |Cyclus| v1.0 we promise API
@@ -352,12 +350,12 @@ command to verify that the release branch is stable:
     $ cd cyclus/release
     $ ./smbchk.py --update -t HEAD --no-save --check
 
-If |cyclus| only has API additions, it is considered stable and the command will 
-tell you so. If |cyclus| also has API deletions, then |cyclus| is considered 
-unstable and a diff of the symbols will be prinited. 
-**You cannot release |cyclus| if it is unstable!** Please post the diff to 
+If |cyclus| only has API additions, it is considered stable and the command will
+tell you so. If |cyclus| also has API deletions, then |cyclus| is considered
+unstable and a diff of the symbols will be prinited.
+**You cannot release |cyclus| if it is unstable!** Please post the diff to
 either the mailing list or the issue tracker and work to resolve the removed
-symbols until it this command declares that |cyclus| is stable. It is 
+symbols until it this command declares that |cyclus| is stable. It is
 probably best to do this prior to any release candidates if possible.
 
 Once stable and there are no more code changes to be made, add the symbols
@@ -369,8 +367,8 @@ you are working on a RELEASE build of Cyclus):
     $ cd cyclus/release
     $ ./smbchk.py --update -t X.X.X
 
-where ``X.X.X`` is the version tag. This should alter the ``symbols.json`` 
-file.  Commit this and add it to the repo.  
+where ``X.X.X`` is the version tag. This should alter the ``symbols.json``
+file.  Commit this and add it to the repo.
 
 Cycamore
 --------
@@ -390,6 +388,7 @@ This document is released under the CC-BY 3.0 license.
 .. _Cyclus: https://github.com/cyclus/cyclus
 .. _Cycamore: https://github.com/cyclus/cycamore
 .. _Cymetric: https://github.com/cyclus/cymetric
-.. _Cyclist: https://github.com/cyclus/cyclist2
+.. _Rickshaw: https://github.com/ergs/rickshaw
+.. _CyclusJS: https://github.com/cyclus/cyclist
 .. _release: https://github.com/cyclus/release
 .. _the fused source directions here: https://code.google.com/p/googletest/wiki/V1_6_AdvancedGuide#Fusing_Google_Test_Source_Files

--- a/source/cep/cep3.rst
+++ b/source/cep/cep3.rst
@@ -81,9 +81,8 @@ accompany any new candidate.
 
 The release branch must be quiet and untouched for *2 - 5 days prior* to the
 full release. When the full and final release happens, the ``vX.X.X-release``
-branch is merged into ``master`` and then deleted. All commits in the
-``vX.X.X-release`` branch must have also been merged into the ``develop`` branch
-as they were accepted.
+branch is deleted. All commits in the ``vX.X.X-release`` branch must have also
+been merged into the ``master`` branch as they were accepted.
 
 Project Checklist
 =================
@@ -352,7 +351,7 @@ command to verify that the release branch is stable:
 
 If |cyclus| only has API additions, it is considered stable and the command will
 tell you so. If |cyclus| also has API deletions, then |cyclus| is considered
-unstable and a diff of the symbols will be prinited.
+unstable and a diff of the symbols will be printed.
 **You cannot release |cyclus| if it is unstable!** Please post the diff to
 either the mailing list or the issue tracker and work to resolve the removed
 symbols until it this command declares that |cyclus| is stable. It is
@@ -389,6 +388,6 @@ This document is released under the CC-BY 3.0 license.
 .. _Cycamore: https://github.com/cyclus/cycamore
 .. _Cymetric: https://github.com/cyclus/cymetric
 .. _Rickshaw: https://github.com/ergs/rickshaw
-.. _CyclusJS: https://github.com/cyclus/cyclist
+.. _CyclusJS: https://github.com/cyclus/cyclist2
 .. _release: https://github.com/cyclus/release
 .. _the fused source directions here: https://code.google.com/p/googletest/wiki/V1_6_AdvancedGuide#Fusing_Google_Test_Source_Files

--- a/source/cep/cep3.rst
+++ b/source/cep/cep3.rst
@@ -261,7 +261,7 @@ Release Process
 
 #. Commit all changes to ``cyclus.github.com`` and ``make gh-publish``
 
-#. Send out an email to `cyclus-dev` and `cyclus-users` to announce the release!
+#. Send out an email to ``cyclus-dev`` and ``cyclus-users`` to announce the release!
 
 
 .. This part has been commented, as it is required for the website, but the


### PR DESCRIPTION
Hello All, This modification to CEP3 proposes that we drop the [GitFlow workflow](https://datasift.github.io/gitflow/IntroducingGitFlow.html) in favor of the master-is-develop workflow.  Many minor modifications had to made throughout the CEP, so the changes are spread out with no single section receiving a major rewrite.

At the community meeting in July, there was support for this.  This will also pave the way for external projects (that is rickshaw) to be brought into the Cyclus organization.