### PR TITLE
CEP27: toolkit Snippet

### DIFF
--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -26,7 +26,7 @@ feature inside multiple archetypes.
 .. _agent-spec-docs:
 
 Agent Spec
-===========
+==========
 
 Agents will be uniquely identified by 3 components together referred to as an
 "agent spec":

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -1,5 +1,5 @@
-CEP 27 - Agent Toolkit Capabilities
-***********************************
+CEP 27 - Toolkit Capabilities Injection into an Archetype
+*********************************************************
 
 :CEP: 27
 :Title: Agent Toolkit Capabilities

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -17,7 +17,7 @@ The |Cyclus| toolkit is designed to easily implement specific capabilities in
 newly developed archetypes, such as a trading policy, commodity producers, etc.
 To add characteristics to archetypes such as `Position` or `Metadata`, the
 actual implementation method is very verbose. It relies on adding the new
-specification in the arcehtype header, assignng it and use it in the cpp
+specification in the arcehtype header, assigning it and use it in the cpp
 file. The developers have to manually ensure the consistency in the variable naming and
 implementation across multiple archetypes/files.
 This CEP explains introduces the concept of snippets to simplify and maintain consistency

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -1,0 +1,96 @@
+CEP 27 - Agent Toolkit Capabilities
+***********************************
+
+:CEP: 27
+:Title: Agent Toolkit Capabilities
+:Last-Modified: 2019-10-28
+:Author: Baptiste Mouginot <mouginot.baptiste@gmail.com>
+:Status: Pending
+:Type: Standards Track
+:Created: Baptiste Mouginot 
+
+Abstract
+========
+
+|Cyclus| toolkit is designed to easily implement specific capabilities in newly
+developed archetypes, such as trading policy, commodity producers... To add
+characteristics to archetypes such as Position or Metadata, the actual
+implementation method is very verbosy where in each archetypes we need to add
+the added specification in the header, assign it and use it in the cpp file,
+without guaranty on the consistency in the variables naming and implementation
+between multiple archetypes.
+This CEP explains how to use snippets to simplify and maintain consistency
+between the different implementation and usage across the implementation of toolkit
+feature inside multiple archetypes.
+
+.. _agent-spec-docs:
+
+Agent Spec
+===========
+
+Agents will be uniquely identified by 3 components together referred to as an
+"agent spec":
+
+1. path: e.g. ``my/module/path``
+
+   A slash-delimited, valid filesystem path relative to CYCLUS_PATH (see
+   Module Discovery below).
+
+2. library: e.g. ``MyModule``
+
+   Name of the compiled shared object library file without the "lib" prefix
+   and without the file extension. If empty, is expanded to the agent class.
+   The example above would correspond to a library file named "libMyModule.so"
+   (linux), "libMyModule.dylib" (darwin), etc.
+
+3. agent class: e.g. ``MyAgent``
+
+   The name of the agent's c++ class as compiled into the shared library file.
+
+An agent spec also has a single-string form composed of the three components
+separated by colons::
+
+    [path]:[library]:[agent-class]
+    
+    e.g. "my/module/path:MyModule:MyAgent"
+
+Example linux agent specs with corresponding filepath expansions::
+
+    my/path:MyModule:MyAgent -> my/path/libMyModule.so
+    my/path::MyAgent         -> my/path/libMyAgent.so
+    :MyModule:MyAgent        -> libMyModule.so
+    ::MyAgent                -> libMyAgent.so
+
+Module Discovery
+================
+
+When running a simulation, |Cyclus| will search the following candidate
+directories (in order) for each given agent spec:
+
+1. Each colon-separated directory in the CYCLUS_PATH environment variable.
+
+2. The default |cyclus| module install directory: ``[install-dir]/lib/cyclus``.
+
+|Cyclus| will check for the library by building consecutive paths with the
+following composition::
+
+    [candidate-dir]/[path]/lib[library][extension]
+
+|Cyclus| uses the first matching shared library file found and assumes the
+specified agent class exists inside it.
+
+Conventions
+============
+
+The path should consist of only alpha-numeric characters, slashes,
+underscores, and dashes. **No** spaces.  If there are resource files that must
+be installed with the shared library file, the library and resources should be
+placed in their own directory.
+
+The shared library name should consist of only alpha-numeric characters,
+slashes, underscores.  **No** spaces. If the shared library only has a
+single agent in it, the library should be the same as the agent class.  For
+example, if my agent was named ``MyAgent``, then the library file should be
+named ``libMyAgent.so`` on a linux system.  This allows the defaults to
+prevent stuttering in the agent's module spec.
+

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -13,13 +13,13 @@ CEP 27 - Agent Toolkit Capabilities
 Abstract
 ========
 
-The |Cyclus| toolkit is designed to easily implement specific capabilities in newly
-developed archetypes, such as trading policy, commodity producers... To add
-characteristics to archetypes such as Position or Metadata, the actual
+The |Cyclus| toolkit is designed to easily implement specific capabilities in
+newly developed archetypes, such as trading policy, commodity producers... To
+add characteristics to archetypes such as Position or Metadata, the actual
 implementation method is very verbose, where in each archetypes one needs to add
-the new specification in the header, assign it and use it in the cpp file,
-with no guarantee on the consistency in the variable naming and implementation
-across multiple archetypes.
+the new specification in the arcehtype header, then assign it and use it in the
+cpp file, with no guarantee on the consistency in the variable naming and
+implementation across multiple archetypes.
 This CEP explains how to use snippets to simplify and maintain consistency
 in the implementation and the usage, across multiple archetypes.
 
@@ -28,16 +28,16 @@ Toolkit Implementation
 ======================
 
 Each |Cyclus| toolkit component will contain 3 different files:
-- 2 for the definition of the snippet C++ class (``cpp`` and header) that allows
+- 2 for the definition of the feature C++ class (``cpp`` and header) that allows
   the use of the capabilities, and optionally to register its values in the
   output database,
 - a snippet definition file used to simplify the implementation and ensure
   consistency accross its integration in the different archetypes.
 
-The snippet definition file will then be included in the header part of the archetypes
-class declaration as: ``#include toolkit/my_snippet.cycpp.h``
-(The use of the ``cycpp.h`` has been chosen to allow syntax highlighting and
-inform developers that this is not a standard C++ header)
+The snippet definition file will be included in the ``private`` section of the
+archetype header as: ``#include toolkit/my_snippet.cycpp.h``. (The use of the
+``cycpp.h`` has been chosen to allow syntax highlighting and inform developers
+that this is not a standard C++ header.)
 
 The snippet file, will contain the declaration of all the variables required
 to use the capabilities class:
@@ -47,10 +47,9 @@ to use the capabilities class:
 - (optional) if the capability requires/allows variable input from users,
   standard |Cyclus| member variable declaration with variable ``#pragma`` is
   required. In addition, to the standard variable declaration and the
-  ``#pragma`` the method also require a ``std::vector<int>
-  cycpp_shape_myvariable0`` to be declared for each of the decorated variable.
-  ``cycpp preprocessor`` is not able at the time to add them automatically for
-  included files.
+  ``#pragma`` the method also require a ``std::vector<int> cycpp_shape_myvariable`` 
+  to be declared for each of the decorated variable. (``cycpp preprocessor`` is not able 
+  at the time to add them automatically for included files.)
 
 
 The main purpose of this include method would be to ensure consistency across
@@ -58,8 +57,8 @@ archetypes using the same toolkit capability requiring user input, avoiding 1
 set of input syntax per archetypes for the same capability.
 
 If the toolkit features needs the capabilities to write in the output database a
-``RecordSnippet(Agent* agent)`` method will be implemented to avoid
-multiplication of implementation in the archetypes.
+``RecordSnippet(Agent* agent)`` method will be implemented in the toolkit class to avoid
+multiplication of implementation in the each archetype using the feature.
 
 
 Archetypes Integration
@@ -68,13 +67,13 @@ Archetypes Integration
 When the capability is integrated in an Archetype the following implementations
 have to be done:
 
-1. Include the snippet in the class header core: ``#include
-   toolkit/my_snippet.cycpp,h``.
+1. Include the snippet in the class header core: 
+   ``#include toolkit/my_snippet.cycpp,h``.
 
 2. Add the proper default initialization of the variable required for the
    snippet.
 
-3. In the ``Archetype::EnterNotify()``, initialise the toolkit class member
+3. (optional) In the ``Archetype::EnterNotify()``, initialise the toolkit class member
    variables with variables.
 
 4. (optional) If required, call the ``RecordSnippet()`` method when necessary during the

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -14,12 +14,12 @@ Abstract
 ========
 
 The |Cyclus| toolkit is designed to easily implement specific capabilities in
-newly developed archetypes, such as a trading policy, commodity producers, etc. To
-add characteristics to archetypes such as `Position` or `Metadata`, the actual
-implementation method is very verbose, where in each archetypes one needs to add
-the new specification in the arcehtype header, then assign it and use it in the
-cpp file, and the developer must ensure the consistency in the variable naming and
-implementation across multiple archetypes.
+newly developed archetypes, such as a trading policy, commodity producers, etc.
+To add characteristics to archetypes such as `Position` or `Metadata`, the
+actual implementation method is very verbose. It relies on adding the new
+specification in the arcehtype header, assignng it and use it in the cpp
+file. The developers have to manually ensure the consistency in the variable naming and
+implementation across multiple archetypes/files.
 This CEP explains introduces the concept of snippets to simplify and maintain consistency
 in the implementation and the usage, across multiple archetypes.
 
@@ -123,7 +123,9 @@ Without Inheritance:
 
 ``my_archetype_example.h``:
 .. highlight:: c
-    class fun_archetype : public cyclus::facility{
+    #include 'toolkit/Position.h'
+    
+     class fun_archetype : public cyclus::facility{
         public:
         [...]
         private:
@@ -163,6 +165,8 @@ With Inheritance:
 
 ``my_archetype_example.h``:
 .. highlight:: c
+    #include 'toolkit/Position.h'
+    
     class fun_archetype : public cyclus::facility, public Position {
         public:
         [...]

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -130,6 +130,7 @@ Without Inheritance:
         private:
         [...]
         #include "toolkit/my_snippet.cycpp.h"
+    }
 
 ``my_archetype_example.cpp``:
 .. highlight:: c
@@ -148,8 +149,9 @@ Without Inheritance:
         coordinates.RecordPosition(this);
         [...]
         }
-Wit Inheritance:
---------------------
+
+With Inheritance:
+-----------------
 ``toolkit/my_snippet.cycpp.h``:
 .. highlight:: c
     #pragma cyclus var { \
@@ -178,6 +180,7 @@ Wit Inheritance:
         private:
         [...]
         #include "toolkit/my_snippet.cycpp.h"
+    }
 
 ``my_archetype_example.cpp``:
 .. highlight:: c

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -17,8 +17,8 @@ The |Cyclus| toolkit is designed to easily implement specific capabilities in
 newly developed archetypes, such as a trading policy, commodity producers, etc.
 To add characteristics to archetypes such as `Position` or `Metadata`, the
 actual implementation method is very verbose. It relies on adding the new
-specification in the arcehtype header, assigning it and use it in the cpp
-file. The developers have to manually ensure the consistency in the variable naming and
+specification in the archetype header, assigning it and use it in the cpp
+file. The developers have to manually ensure the consistency in variable naming and
 implementation across multiple archetypes/files.
 This CEP explains introduces the concept of snippets to simplify and maintain consistency
 in the implementation and the usage, across multiple archetypes.
@@ -44,7 +44,7 @@ to use the capabilities class:
 
 - the definition of the capability class as a member variable.
 
-- initialisation of the added variables.
+- initialization of the added variables.
 
 - (optional) if the capability requires/allows variable input from users,
   standard |Cyclus| member variable declaration with variable ``#pragma`` is

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -35,7 +35,7 @@ Each |Cyclus| toolkit component will contain 3 different files:
   consistency accross its integration in the different archetypes.
 
 The snippet definition file will be included in the ``private`` section of the
-archetype header as: ``#include toolkit/my_snippet.cycpp.h``. (The use of the
+archetype header as: ``#include toolkit/my_feature_snippet.cycpp.h``. (The use of the
 ``cycpp.h`` has been chosen to allow syntax highlighting and inform developers
 that this is not a standard C++ header.)
 
@@ -51,7 +51,7 @@ to use the capabilities class:
   required. In addition, to the standard variable declaration and the
   ``#pragma`` the method also require a ``std::vector<int>
   cycpp_shape_myvariable`` to be declared for each of the decorated variable
-  that are in the `toolkit/my_snippet.cycpp.h` file. (``cycpp preprocessor`` is
+  that are in the `toolkit/my_feature_snippet.cycpp.h` file. (``cycpp preprocessor`` is
   not able at the time to add them automatically for included files.)
 
 
@@ -70,13 +70,16 @@ Archetypes Integration
 When the capability is integrated in an Archetype the following implementations
 have to be done:
 
-1. Include the snippet in the class header core: 
-   ``#include toolkit/my_snippet.cycpp,h``.
+1. Include toolkit class header in in the class header:
+   ``#include 'toolkit/my_feature.h'``.
 
-2. (optional) In the ``Archetype::EnterNotify()``, initialise the toolkit class member
+2. Include the snippet in the class header core: 
+   ``#include toolkit/my_feature_snippet.cycpp,h``.
+
+3. (optional) In the ``Archetype::EnterNotify()``, initialise the toolkit class member
    variables with variables.
 
-3. (optional) If required, call the ``RecordSnippet()`` method when necessary during the
+4. (optional) If required, call the ``RecordSnippet()`` method when necessary during the
    Archetype operation.
 
 
@@ -99,7 +102,7 @@ Example:
 
 Without Inheritance:
 --------------------
-``toolkit/my_snippet.cycpp.h``:
+``toolkit/my_feature_snippet.cycpp.h``:
 .. highlight:: c
     cyclus::toolkit::Position coordinates(0,0);
 
@@ -130,7 +133,7 @@ Without Inheritance:
         [...]
         private:
         [...]
-        #include "toolkit/my_snippet.cycpp.h"
+        #include "toolkit/my_feature_snippet.cycpp.h"
     }
 
 ``my_archetype_example.cpp``:
@@ -143,7 +146,7 @@ Without Inheritance:
 
 With Inheritance:
 -----------------
-``toolkit/my_snippet.cycpp.h``:
+``toolkit/my_feature_snippet.cycpp.h``:
 .. highlight:: c
     #pragma cyclus var { \
         "default": 0.0, \
@@ -172,7 +175,7 @@ With Inheritance:
         [...]
         private:
         [...]
-        #include "toolkit/my_snippet.cycpp.h"
+        #include "toolkit/my_feature_snippet.cycpp.h"
     }
 
 ``my_archetype_example.cpp``:

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -13,27 +13,27 @@ CEP 27 - Agent Toolkit Capabilities
 Abstract
 ========
 
-|Cyclus| toolkit is designed to easily implement specific capabilities in newly
+The |Cyclus| toolkit is designed to easily implement specific capabilities in newly
 developed archetypes, such as trading policy, commodity producers... To add
 characteristics to archetypes such as Position or Metadata, the actual
-implementation method is very verbosy where in each archetypes one need to add
-the inew specification in the header, assign it and use it in the cpp file,
-without guaranty on the consistency in the variables naming and implementation
+implementation method is very verbose, where in each archetypes one needs to add
+the new specification in the header, assign it and use it in the cpp file,
+with no guarantee on the consistency in the variable naming and implementation
 across multiple archetypes.
-This CEP explains how to use snippets would simplify and maintain consistency
+This CEP explains how to use snippets to simplify and maintain consistency
 in the implementation and the usage, across multiple archetypes.
 
 
 Toolkit Implementation
 ======================
 
-The |Cyclus| toolkit will contain 3 different files: 2 for the definition of the
-snippet C++ class (``cpp`` and header) that allows to use the capabilities, and
+Each |Cyclus| toolkit component will contain 3 different files: 2 for the definition of the
+snippet C++ class (``cpp`` and header) that allows the use of the capabilities, and
 optionally to register its values in the output database, a snippet simplifying
 the integration of the feature in a newly develop archetypes.
 
 The snippet file with then be included in the header part of the archetypes
-class declaration as": ``#include toolkit/my_snippet.cycpp.h``
+class declaration as: ``#include toolkit/my_snippet.cycpp.h``
 
 (The use of the ``cycpp.h`` has been chosen to allow syntax highlighting and
 inform developers that this is not a standard C++ header)
@@ -51,11 +51,11 @@ to use the capabilities class:
   included files.
 
 
-The main interest of this include method would be to insure consistency across
+The main purpose of this include method would be to ensure consistency across
 archetypes using the same toolkit capability requiring user input, avoiding 1
 set of input syntax per archetypes for the same capability.
 
-If the toolkit features needs to capabilities to write in the output database a
+If the toolkit features needs the capabilities to write in the output database a
 ``RecordSnippet(Agent* agent)`` method will be implemented to avoid
 multiplication of implementation in the archetypes.
 
@@ -69,7 +69,7 @@ have to be done:
 1. Include the snippet in the class header core: ``#include
    toolkit/my_snippet.cycpp,h``.
 
-2. Add the proper default initialisation of the variable required for the
+2. Add the proper default initialization of the variable required for the
    snippet.
 
 3. In the ``Archetype::EnterNotify()``, assign the Snippet with value

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -44,6 +44,8 @@ to use the capabilities class:
 
 - the definition of the capability class as a member variable.
 
+- initialisation of the added variables.
+
 - (optional) if the capability requires/allows variable input from users,
   standard |Cyclus| member variable declaration with variable ``#pragma`` is
   required. In addition, to the standard variable declaration and the
@@ -71,13 +73,10 @@ have to be done:
 1. Include the snippet in the class header core: 
    ``#include toolkit/my_snippet.cycpp,h``.
 
-2. Add the proper default initialization of the variable required for the
-   snippet.
-
-3. (optional) In the ``Archetype::EnterNotify()``, initialise the toolkit class member
+2. (optional) In the ``Archetype::EnterNotify()``, initialise the toolkit class member
    variables with variables.
 
-4. (optional) If required, call the ``RecordSnippet()`` method when necessary during the
+3. (optional) If required, call the ``RecordSnippet()`` method when necessary during the
    Archetype operation.
 
 
@@ -102,14 +101,14 @@ Without Inheritance:
 --------------------
 ``toolkit/my_snippet.cycpp.h``:
 .. highlight:: c
-    cyclus::toolkit::Position coordinates;
+    cyclus::toolkit::Position coordinates(0,0);
 
     #pragma cyclus var { \
         "default": 0.0, \
         "uilabel": "Geographical latitude in degrees as a double", \
         "doc": "Latitude of the agent's geographical position. The value should " \
            "be expressed in degrees as a double." }
-    double latitude;
+    double latitude = 0;
     // required for compilation but not added by the cycpp preprocessor...
     std::vector<int> cycpp_shape_latitude;
 
@@ -118,7 +117,7 @@ Without Inheritance:
            "uilabel": "Geographical longitude in degrees as a double", \
            "doc": "Longitude of the agent's geographical position. The value should" \
            "be expressed in degrees as a double." }
-    double longitude;
+    double longitude = 0;
     // required for compilation but not added by the cycpp preprocessor...
     std::vector<int> cycpp_shape_longitude;
 
@@ -134,17 +133,7 @@ Without Inheritance:
 
 ``my_archetype_example.cpp``:
 .. highlight:: c
-    fun_archetype::fun_archetype(cyclus::Context* ctx):
-        cyclus::facility(ctx),
-        var1(0.0),
-        var2(0.0),
-        ...,
-        coordinates(0,0), //coordinates constructor (toolkit feature class)
-        longitude(0), //snippet variables added with "my_snippet.cycpp.h"
-        latitude(0) //snippet variables added with "my_snippet.cycpp.h"
-    {}
-    [..]
-    void Storage::EnterNotify() {
+    void fun_archetype::EnterNotify() {
         coordinates.set_position(latitude, longitude);
         coordinates.RecordPosition(this);
         [...]
@@ -159,7 +148,7 @@ With Inheritance:
         "uilabel": "Geographical latitude in degrees as a double", \
         "doc": "Latitude of the agent's geographical position. The value should " \
            "be expressed in degrees as a double." }
-    double latitude;
+    double latitude = 0;
     // required for compilation but not added by the cycpp preprocessor...
     std::vector<int> cycpp_shape_latitude;
 
@@ -168,7 +157,7 @@ With Inheritance:
            "uilabel": "Geographical longitude in degrees as a double", \
            "doc": "Longitude of the agent's geographical position. The value should" \
            "be expressed in degrees as a double." }
-    double longitude;
+    double longitude = 0;
     // required for compilation but not added by the cycpp preprocessor...
     std::vector<int> cycpp_shape_longitude;
 
@@ -184,18 +173,7 @@ With Inheritance:
 
 ``my_archetype_example.cpp``:
 .. highlight:: c
-    fun_archetype::fun_archetype(cyclus::Context* ctx):
-        cyclus::facility(ctx),
-        var1(0.0),
-        var2(0.0),
-        ...,
-        coordinates(0,0), //coordinates constructor (toolkit feature class)
-        longitude(0), //snippet variables added with "my_snippet.cycpp.h"
-        latitude(0), //snippet variables added with "my_snippet.cycpp.h"
-        Position(0, 0)
-    {}
-    [..]
-    void Storage::EnterNotify() {
+    void fun_archetype::EnterNotify() {
         this.set_position(latitude, longitude);
         this.RecordPosition(this);
         [...]

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -7,7 +7,8 @@ CEP 27 - Agent Toolkit Capabilities
 :Author: Baptiste Mouginot <mouginot.baptiste@gmail.com>
 :Status: Active
 :Type: Standards Track
-:Created: Baptiste Mouginot 
+:Created: Baptiste Mouginot
+
 
 Abstract
 ========
@@ -15,34 +16,31 @@ Abstract
 |Cyclus| toolkit is designed to easily implement specific capabilities in newly
 developed archetypes, such as trading policy, commodity producers... To add
 characteristics to archetypes such as Position or Metadata, the actual
-implementation method is very verbosy where in each archetypes we need to add
-the added specification in the header, assign it and use it in the cpp file,
+implementation method is very verbosy where in each archetypes one need to add
+the inew specification in the header, assign it and use it in the cpp file,
 without guaranty on the consistency in the variables naming and implementation
-between multiple archetypes.
-This CEP explains how to use snippets to simplify and maintain consistency
-between the different implementation and usage across the implementation of toolkit
-feature inside multiple archetypes.
+across multiple archetypes.
+This CEP explains how to use snippets would simplify and maintain consistency
+in the implementation and the usage, across multiple archetypes.
 
-.. _agent-spec-docs:
 
 Toolkit Implementation
 ======================
 
-The |Cyclus| toolkit will contain 3 different files: i2 for the definition of
-the snippet class element (``cpp`` and header) that allows to use the
-capabilities, and optionally to register its values in the output database, a
-snippet simplifying the integration of the feature in a newly develop
-archetypes.
+The |Cyclus| toolkit will contain 3 different files: 2 for the definition of the
+snippet C++ class (``cpp`` and header) that allows to use the capabilities, and
+optionally to register its values in the output database, a snippet simplifying
+the integration of the feature in a newly develop archetypes.
 
 The snippet file with then be included in the header part of the archetypes
 class declaration as": ``#include toolkit/my_snippet.cycpp.h``
 
 (The use of the ``cycpp.h`` has been chosen to allow syntax highlighting and
 inform developers that this is not a standard C++ header)
-The snippet file, will contain all the declaration of all the variable required
+The snippet file, will contain the declaration of all the variables required
 to use the capabilities class:
 
-- the definition of the capability class as a member variable
+- the definition of the capability class as a member variable.
 
 - (optional) if the capability requires/allows variable input from users,
   standard |Cyclus| member variable declaration with variable ``#pragma`` is
@@ -52,8 +50,9 @@ to use the capabilities class:
   ``cycpp preprocessor`` is not able at the time to add them automatically for
   included files.
 
+
 The main interest of this include method would be to insure consistency across
-archetypes using the same toolkit capability requiring user input.i, avoiding 1
+archetypes using the same toolkit capability requiring user input, avoiding 1
 set of input syntax per archetypes for the same capability.
 
 If the toolkit features needs to capabilities to write in the output database a
@@ -64,14 +63,14 @@ multiplication of implementation in the archetypes.
 Archetypes Integration
 ======================
 
-When the capability is integrated in an Archetype the following implementation
+When the capability is integrated in an Archetype the following implementations
 have to be done:
 
 1. Include the snippet in the class header core: ``#include
-   toolkit/my_snippet.cycpp,h``
+   toolkit/my_snippet.cycpp,h``.
 
 2. Add the proper default initialisation of the variable required for the
-   snippet
+   snippet.
 
 3. In the ``Archetype::EnterNotify()``, assign the Snippet with value
    corresponding to the user input.
@@ -79,17 +78,17 @@ have to be done:
 4. (optional) If required, call the ``RecordSnippet()`` method when necessary during the
    Archetype operation.
 
+
 Class member vs Inheritance
 ===========================
 
-The main issue with inheriting of the capability class is that one will need to
-also modify the archetype class declaration in addition to simply including the
-snippet at the right place.
-
+With inheritance of the capability class, one will need to also modify the
+archetype class declaration in addition to simply including the snippet at the
+right place.
 This may also lead to confusion, as one can believe that the user input value
 for variable are passed in the constructor of the class and might lead the
 develop to skip the assignation of the value in the inherited class in the
 ``EnterNotify``...
 
-Otherwise behavior would be similar.
+Otherwise behavior would be very similar.
 

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -97,6 +97,9 @@ Otherwise behavior would be very similar.
 Example:
 ========
 
+
+Without Inheritance:
+--------------------
 ``toolkit/my_snippet.cycpp.h``:
 .. highlight:: c
     cyclus::toolkit::Position coordinates;
@@ -118,7 +121,6 @@ Example:
     double longitude;
     // required for compilation but not added by the cycpp preprocessor...
     std::vector<int> cycpp_shape_longitude;
-
 
 ``my_archetype_example.h``:
 .. highlight:: c
@@ -144,5 +146,54 @@ Example:
     void Storage::EnterNotify() {
         coordinates.set_position(latitude, longitude);
         coordinates.RecordPosition(this);
+        [...]
+        }
+Wit Inheritance:
+--------------------
+``toolkit/my_snippet.cycpp.h``:
+.. highlight:: c
+    #pragma cyclus var { \
+        "default": 0.0, \
+        "uilabel": "Geographical latitude in degrees as a double", \
+        "doc": "Latitude of the agent's geographical position. The value should " \
+           "be expressed in degrees as a double." }
+    double latitude;
+    // required for compilation but not added by the cycpp preprocessor...
+    std::vector<int> cycpp_shape_latitude;
+
+    #pragma cyclus var { \
+           "default": 0.0, \
+           "uilabel": "Geographical longitude in degrees as a double", \
+           "doc": "Longitude of the agent's geographical position. The value should" \
+           "be expressed in degrees as a double." }
+    double longitude;
+    // required for compilation but not added by the cycpp preprocessor...
+    std::vector<int> cycpp_shape_longitude;
+
+``my_archetype_example.h``:
+.. highlight:: c
+    class fun_archetype : public cyclus::facility, public Position {
+        public:
+        [...]
+        private:
+        [...]
+        #include "toolkit/my_snippet.cycpp.h"
+
+``my_archetype_example.cpp``:
+.. highlight:: c
+    fun_archetype::fun_archetype(cyclus::Context* ctx):
+        cyclus::facility(ctx),
+        var1(0.0),
+        var2(0.0),
+        ...,
+        coordinates(0,0), //coordinates constructor (toolkit feature class)
+        longitude(0), //snippet variables added with "my_snippet.cycpp.h"
+        latitude(0), //snippet variables added with "my_snippet.cycpp.h"
+        Position(0, 0)
+    {}
+    [..]
+    void Storage::EnterNotify() {
+        this.set_position(latitude, longitude);
+        this.RecordPosition(this);
         [...]
         }

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -47,9 +47,10 @@ to use the capabilities class:
 - (optional) if the capability requires/allows variable input from users,
   standard |Cyclus| member variable declaration with variable ``#pragma`` is
   required. In addition, to the standard variable declaration and the
-  ``#pragma`` the method also require a ``std::vector<int> cycpp_shape_myvariable`` 
-  to be declared for each of the decorated variable. (``cycpp preprocessor`` is not able 
-  at the time to add them automatically for included files.)
+  ``#pragma`` the method also require a ``std::vector<int>
+  cycpp_shape_myvariable`` to be declared for each of the decorated variable
+  that are in the `toolkit/my_snippet.cycpp.h` file. (``cycpp preprocessor`` is
+  not able at the time to add them automatically for included files.)
 
 
 The main purpose of this include method would be to ensure consistency across

--- a/source/cep/cep27.rst
+++ b/source/cep/cep27.rst
@@ -100,7 +100,7 @@ Exemple:
 ``toolkit/my_snippet.cycpp.h``:
 .. highlight:: c
     cyclus::toolkit::Position coordinates;
-    
+
     #pragma cyclus var { \
         "default": 0.0, \
         "uilabel": "Geographical latitude in degrees as a double", \
@@ -131,7 +131,7 @@ Exemple:
 
 ``my_archetype_example.cpp``:
 .. highlight:: c
-    fun_archetype::fun_archetype(cyclus::Context* ctx): 
+    fun_archetype::fun_archetype(cyclus::Context* ctx):
         cyclus::facility(ctx),
         var1(0.0),
         var2(0.0),


### PR DESCRIPTION
This is a suggestion to improve, ease and homogenize an the usage of toolkit capability in archetypes.

This idea is to limit as much as possible the need for implementation in a newly develop archetypes to avoid divergence in the implementation and the convention by providing a snippet that one can simply includes in the archetypes class definition header (inside the core definition of the class) to ensure variable name are identical.

Example can be found in:
- cyclus/cyclus#1510 for the snippet implementation
- cyclus/cycamore#502 for the corresponding archetypes implementations
