### PR TITLE
CEP3: Updating Cyclus Release Procedure Instructions

### DIFF
--- a/source/cep/cep3.rst
+++ b/source/cep/cep3.rst
@@ -247,7 +247,8 @@ Release Process
 
     - In each project's feedstok, open up a PR which updates the
       `recipe/meta.yaml` file with the new version number and the new SHA-256
-      value of the new version's tarball. See conda-forge documentation for more
+      value of the new version's tarball (Note: the above scripts may
+      automatically create a new PR). See conda-forge documentation for more
       or ask the feedstock maintainers for help.
 
     - Note that each feedstock must be accepted and the package uploaded to

--- a/source/cep/cep3.rst
+++ b/source/cep/cep3.rst
@@ -128,7 +128,7 @@ Release Process
 #. Make sure every local |cyclus| project repository is up to date with its
    ``master``, and ``vX.X.X-release`` branches on ``upstream``.
 
-#. Bump the version in ``cyclus/src/version.h.in``,
+#. Bump the version in ``cyclus/src/version.h.in`` and ``cyclus/cyclus/__init__.py``,
    ``cycamore/src/cycamore_version.h.in``, and
    ``cymetric/setup.py``; commit the changes
 

--- a/source/cep/cep3.rst
+++ b/source/cep/cep3.rst
@@ -133,19 +133,20 @@ Release Process
    ``cymetric/setup.py``; commit the changes
 
 #. Perform maintenance tasks for all projects. The maintenance depends on `PyNE
-   <https://github.com/pyne/pyne.git>`_ and Doxygen.
+   <https://github.com/pyne/pyne.git>`_ and Doxygen. Maintenance files can be
+   found `here<https://github.com/cyclus/release>`_.
 
-    - they are described in detail below, *but* the ``maintenence.sh`` utility
+    - they are described in detail below, *but* the ``maintenance.sh`` utility
       in ``release/utils`` will do this automatically for you
 
-    - make sure to have your ``rs.cred`` file (see ``maintenence.sh``'s help)
+    - make sure to have your ``rs.cred`` file (see ``maintenance.sh``'s help)
 
     .. code-block:: bash
 
       $ cd /path/to/release/utils
       $ export CYCLUS_DIR=/path/to/cyclus
       $ export CYCAMORE_DIR=/path/to/cycamore
-      $ ./maintenence.sh -r -v X.X.X # X.X.X is *this* version
+      $ ./maintenance.sh -r -v X.X.X # X.X.X is *this* version
 
     .. note::
 

--- a/source/cep/cep3.rst
+++ b/source/cep/cep3.rst
@@ -247,8 +247,7 @@ Release Process
 
     - In each project's feedstok, open up a PR which updates the
       `recipe/meta.yaml` file with the new version number and the new SHA-256
-      value of the new version's tarball (Note: the above scripts may
-      automatically create a new PR). See conda-forge documentation for more
+      value of the new version's tarball. See conda-forge documentation for more
       or ask the feedstock maintainers for help.
 
     - Note that each feedstock must be accepted and the package uploaded to

--- a/source/cep/cep3.rst
+++ b/source/cep/cep3.rst
@@ -134,7 +134,8 @@ Release Process
 
 #. Perform maintenance tasks for all projects. The maintenance depends on `PyNE
    <https://github.com/pyne/pyne.git>`_ and Doxygen. Maintenance files can be
-   found `here<https://github.com/cyclus/release>`_.
+   found `here
+   <https://github.com/cyclus/release>`_.
 
     - they are described in detail below, *but* the ``maintenance.sh`` utility
       in ``release/utils`` will do this automatically for you
@@ -231,11 +232,11 @@ Release Process
       $ cd /path/to/project
       $ git push upstream X.X.X master
       $ git push upstream --delete vX.X.X-release
+      
+#. Manually visit the github.com page for each project and draft/publish a new release.
 
-#. Manually visit the github.com page for each project and mark the tags as releases.
-
-    - This can be updated one day to use the Github `release API
-      <https://developer.github.com/v3/repos/releases/#create-a-release>`_
+    - See instructions `here
+      <https://help.github.com/en/github/administering-a-repository/creating-releases>`_
 
 
 #. Update Conda-forge


### PR DESCRIPTION
This file includes a version number that should be updated when bumping version numbers for new releases. I've added the file to the instructions.