### PR TITLE
force updating/creating local/master from upstream/master on publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,8 @@ gh-publish-only:
 	rsync -a $(BUILDDIR)/.* .
 	git add -f `(cd $(BUILDDIR); find . -type f; cd ..)`
 	rm -rf $(GH_SOURCE_DIR) $(BUILDDIR)
-	#git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push --force $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
-	#git checkout $(GH_SOURCE_BRANCH)
+	git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push --force $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
+	git checkout $(GH_SOURCE_BRANCH)
 
 gh-publish:
 	make clean

--- a/Makefile
+++ b/Makefile
@@ -80,14 +80,14 @@ gh-preview html:
 gh-publish-only:
 	git fetch $(GH_UPSTREAM_REPO)
 	git checkout -B $(GH_PUBLISH_BRANCH) $(GH_UPSTREAM_REPO)/$(GH_PUBLISH_BRANCH)
-	git checkout $(GH_SOURCE_BRANCH) -- $(GH_SOURCE_DIR)
+	git checkout $(GH_UPSTREAM_REPO)/$(GH_SOURCE_BRANCH) -- $(GH_SOURCE_DIR)
 	git reset HEAD
 	rsync -a $(BUILDDIR)/* .
 	rsync -a $(BUILDDIR)/.* .
 	git add -f `(cd $(BUILDDIR); find . -type f; cd ..)`
 	rm -rf $(GH_SOURCE_DIR) $(BUILDDIR)
-	git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push --force $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
-	git checkout $(GH_SOURCE_BRANCH)
+	#git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push --force $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
+	#git checkout $(GH_SOURCE_BRANCH)
 
 gh-publish:
 	make clean

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ gh-preview html:
 
 gh-publish-only:
 	git fetch $(GH_UPSTREAM_REPO)
-	git checkout -b $(GH_PUBLISH_BRANCH) $(GH_UPSTREAM_REPO)/$(GH_PUBLISH_BRANCH)
+	git checkout -B $(GH_PUBLISH_BRANCH) $(GH_UPSTREAM_REPO)/$(GH_PUBLISH_BRANCH)
 	git checkout $(GH_SOURCE_BRANCH) -- $(GH_SOURCE_DIR)
 	git reset HEAD
 	rsync -a $(BUILDDIR)/* .

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ gh-publish-only:
 	rsync -a $(BUILDDIR)/.* .
 	git add -f `(cd $(BUILDDIR); find . -type f; cd ..)`
 	rm -rf $(GH_SOURCE_DIR) $(BUILDDIR)
-	git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push --force $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
+	#git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push --force $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
 	git checkout $(GH_SOURCE_BRANCH)
 
 gh-publish:

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,9 @@ gh-preview html:
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)."
 
 gh-publish-only:
-	git checkout $(GH_PUBLISH_BRANCH)
+	git fetch $(GH_UPSTREAM_REPO)
+	git branch -Df $(GH_PUBLISH_BRANCH)
+	git checkout -b $(GH_PUBLISH_BRANCH) $(GH_UPSTREAM_REPO)/$(GH_PUBLISH_BRANCH)
 	git checkout $(GH_SOURCE_BRANCH) -- $(GH_SOURCE_DIR)
 	git reset HEAD
 	rsync -a $(BUILDDIR)/* .

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,6 @@ gh-preview html:
 
 gh-publish-only:
 	git fetch $(GH_UPSTREAM_REPO)
-	git branch -Df $(GH_PUBLISH_BRANCH)
 	git checkout -b $(GH_PUBLISH_BRANCH) $(GH_UPSTREAM_REPO)/$(GH_PUBLISH_BRANCH)
 	git checkout $(GH_SOURCE_BRANCH) -- $(GH_SOURCE_DIR)
 	git reset HEAD

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ gh-publish-only:
 	git reset HEAD
 	rsync -a $(BUILDDIR)/* .
 	rsync -a $(BUILDDIR)/.* .
-	git add `(cd $(BUILDDIR); find . -type f; cd ..)`
+	git add -f `(cd $(BUILDDIR); find . -type f; cd ..)`
 	rm -rf $(GH_SOURCE_DIR) $(BUILDDIR)
 	git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push --force $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
 	git checkout $(GH_SOURCE_BRANCH)

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ gh-publish-only:
 	rsync -a $(BUILDDIR)/.* .
 	git add -f `(cd $(BUILDDIR); find . -type f; cd ..)`
 	rm -rf $(GH_SOURCE_DIR) $(BUILDDIR)
-	#git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push --force $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
+	git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push --force $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
 	git checkout $(GH_SOURCE_BRANCH)
 
 gh-publish:

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,6 @@ gh-preview html:
 gh-publish-only:
 	git fetch $(GH_UPSTREAM_REPO)
 	git checkout -B $(GH_PUBLISH_BRANCH) $(GH_UPSTREAM_REPO)/$(GH_PUBLISH_BRANCH)
-	git checkout $(GH_UPSTREAM_REPO)/$(GH_SOURCE_BRANCH) -- $(GH_SOURCE_DIR)
 	git reset HEAD
 	rsync -a $(BUILDDIR)/* .
 	rsync -a $(BUILDDIR)/.* .


### PR DESCRIPTION
Added this, to ensure `make xxx-publish` is using an up-to-date version of `master` and `source` to build and publish the last version of the website.



Context:
Earlier today, I try to publish the new version of the website, the process requires you to have a local `master` branch, which I did not have... So I created it from `source` not from `upstream/master`.
I then ran the build and publish process (which updates and push a new version of `master`) but as my `master` was a copy of `source` and not `master` it did not include the pre-built files required for the website... and so it broke the website...

This should ensure that nobody make this kind of mistake in the future:
the `git check -B master upstream/master` creates a new `master` branch locally if it did not already exist, or resets it to `upstream/master` if existing...
