### PR TITLE
proliferate foot notes about order

### DIFF
--- a/source/user/tutorial/add_arche.rst
+++ b/source/user/tutorial/add_arche.rst
@@ -204,8 +204,4 @@ Once complete, append the archetypes section under the control section of input 
 
 .. rubric:: Footnotes
 
-.. [#f1] The exact order of the sections in a |Cyclus| input file are of minor
-consequence. The ``control`` sequence must go first, but the other sequences
- can go in any order that makes sense to the user. The traditional organization
-  of an input file is: control, archetypes, commodities, facilities,
-   regions/institutions, and recipes. 
+.. [#f1] The exact order of the sections in a |Cyclus| input file are of minor consequence. The ``control`` sequence must go first, but the other sequences can go in any order that makes sense to the user. The traditional organization  of an input file is: control, archetypes, commodities, facilities,   regions/institutions, and recipes. 

--- a/source/user/tutorial/add_commod_recipe.rst
+++ b/source/user/tutorial/add_commod_recipe.rst
@@ -156,7 +156,7 @@ inside a ``commodity`` block.
       <solution_priority>1.0</solution_priority>
     </commodity>
 
-Once complete, append the commodities section under the archetypes section.
+Once complete, append the commodities section under the archetypes section [#f1]_.
 
 Understanding Recipes
 ---------------------
@@ -362,7 +362,7 @@ The recipe section of this tutorial is placed below.
       </nuclide>
     </recipe>
 
-Once complete, append this facility under the commodity section of your input file.
+Once complete, append this facility under the commodity section of your input file [#f1]_.
 
 
 Let's take a look at the ``fresh-uox`` fuel recipe:
@@ -372,3 +372,5 @@ Let's take a look at the ``fresh-uox`` fuel recipe:
     :alt: Fuel recipe for fresh-uox
 The recipe name ``fresh-uox`` is specified, as are the isotope nuclide IDs and the 
 corresponding mass fraction of each nuclide. The ``fresh-uox`` is composed of 4% U-235 and 96% U-238.
+
+.. [#f1] The exact order of the sections in a |Cyclus| input file are of minor consequence. The ``control`` sequence must go first, but the other sequences can go in any order that makes sense to the user. The traditional organization  of an input file is: control, archetypes, commodities, facilities,   regions/institutions, and recipes. 

--- a/source/user/tutorial/add_proto.rst
+++ b/source/user/tutorial/add_proto.rst
@@ -123,7 +123,7 @@ Archetype and the table below, create the UraniumMine prototype.
     </config>
   </facility>
 
-Once complete, append this facility under the commodity section and before the recipe section of your input file.
+Once complete, append this facility under the commodity section and before the recipe section of your input file [#f1]_.
 
 Example: Enrichment Prototype
 +++++++++++++++++++++++++++++
@@ -250,7 +250,7 @@ After filling in these variables, your enrichment facility prototype will look l
     </config>
   </facility>
 
-Once complete, append this facility under the Source prototype of your input file.
+Once complete, append this facility under the Source prototype of your input file [#f1]_.
 
 
 Example: Reactor Prototype
@@ -401,7 +401,7 @@ Once completed, your prototype should look like:
         </config>
       </facility>
 
-Once complete, append this facility under the Enrichment facility of your input file.
+Once complete, append this facility under the Enrichment facility of your input file [#f1]_.
 
 
 Example: Sink Prototype
@@ -511,7 +511,7 @@ After filling in these variables, your sink facility prototype will look like:
     </config>
   </facility>
 
-Once complete, append this facility under the Reactor prototype of your input file.
+Once complete, append this facility under the Reactor prototype of your input file [#f1]_.
 
 Check: Complete Facility block
 ++++++++++++++++++++++++++++++++++++++++
@@ -571,3 +571,5 @@ The facility section of your input file should be of the form:
       </Sink>
     </config>
   </facility>
+
+.. [#f1] The exact order of the sections in a |Cyclus| input file are of minor consequence. The ``control`` sequence must go first, but the other sequences can go in any order that makes sense to the user. The traditional organization  of an input file is: control, archetypes, commodities, facilities,   regions/institutions, and recipes. 


### PR DESCRIPTION
Fixes #311 

The footnote that clarifies that order doesn't matter is repeated more often.