### PR TITLE
expose both archetype tutorials on sidebar menu

### DIFF
--- a/source/atemplates/layout.html
+++ b/source/atemplates/layout.html
@@ -8,7 +8,8 @@
     <li><a href="/user/index.html">User Guide</a></li>
     <li><a href="/user/tutorial/index.html">User Tutorial</a></li>
     <li><a href="/arche/index.html">Archetype Developer Guide</a></li>
-    <li><a href="/arche/tutorial/index.html">Archetype Developer Tutorial</a></li>
+    <li><a href="/arche/tutorial_cpp/index.html">Archetype Developer C++ Tutorial</a></li>
+    <li><a href="/arche/tutorial_py/index.html">Archetype Developer Python Tutorial</a></li>
      <li><a href="http://fuelcycle.org/cyclus/api/">Cyclus API Documentation</a></li>
     <li><a href="http://fuelcycle.org/cycamore/api/">Cycamore API Documentation</a></li>
     <li><a href="/basics/glossary.html">Glossary</a></li>


### PR DESCRIPTION
The sidebar menu in the layout template only refers to a single archetype developer tutorial, with the wrong URL.

Fixes cyclus/cyclus#1565 