### PR TITLE
Update Python API for archetype development

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Building the Cyclus website requires:
 
 **NOTE:** The cloud package for Debian and Ubuntu is broken, so do not apt-get
 this. Please ``pip install cloud_sptheme``, ``easy_install cloud_sptheme``, or install from source instead.
-If installing from pip, install the source (``pip install no-binary=cloud_sptheme cloud_sptheme)``, then 
+If installing from pip, install the source (``pip install no-binary=cloud_sptheme cloud_sptheme``), then 
 use `this patch <https://foss.heptapod.net/doc-utils/cloud_sptheme/-/issues/47>`
 to fix a bug in the package. 
 

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,9 @@ Building the Cyclus website requires:
 
 **NOTE:** The cloud package for Debian and Ubuntu is broken, so do not apt-get
 this. Please ``pip install cloud_sptheme``, ``easy_install cloud_sptheme``, or install from source instead.
+If installing from pip, install the source (``pip install no-binary=cloud_sptheme cloud_sptheme)``, then 
+use `this patch <https://foss.heptapod.net/doc-utils/cloud_sptheme/-/issues/47>`
+to fix a bug in the package. 
 
 Modifying the Cyclus Website
 ============================

--- a/source/arche/dre.rst
+++ b/source/arche/dre.rst
@@ -80,16 +80,21 @@ be:
       ports.insert(port);
       return ports;
 
-      // To make the request more complex, you can add preferences to 
-      // each request (argument 4), make them exclusive (argument 5), 
-      // and make the requests mutual:
+      // In this example, both the FuelA and FuelB commodities can meet the 
+      // material request, but FuelA is preferred. So we define a preference 
+      // for each commodity as the fourth argument in the function. 
+      // The larger the preference value, the more the commodity is preferred. 
+      // The fifth argument here is if the request is exclusive: 
       std::set<RequestPortfolio<Material>::Ptr> ports;
       RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
-      std::vector<Request<Material>*> mreqs; 
+      
       double prefA = 2;
       double prefB = 1;
       Request<Material>* r1 = port->AddRequest(targeta, this, commodA, prefA, true);
       Request<Material>* r2 = port->AddRequest(targetb, this, commodB, prefB, true);
+
+      // Additionally, we can create a vector of requests that are mutual: 
+      std::vector<Request<Material>*> mreqs; 
       mreqs = {r1, r2}; 
       port->AddMutualReqs(mreqs);
       ports.insert(port);
@@ -129,10 +134,11 @@ be:
         port = {"commodities": commods, "constraints": [request_qty, request_qty*2]}
         return port
 
-        # If you want to define multiple commodities as mutual requests, such that 
-        # any of them would meet the request, but one is preferred over the other
-        # you need to add preferences to each commodity. 
-        # The larger value indicates a greater preference:
+        # In this example, both the FuelA and FuelB commodities can meet the 
+        # material request, but FuelA is preferred. So we define a preference 
+        # for each commodity. The larger the preference value, the 
+        # more the commodity is preferred. Placing the dictionaries in
+        # a list makes them mutual requests:
         commods = [{"FuelA": target_a, "preference":2}, 
                    {"FuelB": target_b, "preference":1}]
         port = {"commodities":commods, "constraints":request_qty
@@ -145,9 +151,9 @@ be:
 
         # lastly, if you need to return many portfolios, simply return a list of
         # portfolio dictionaries! The "preference" and "exclusive" keys are optional
-        ports = [{"commodities": {"FuelA": target_a, "preference": 2, "exclusive": True}, 
+        ports = [{"commodities": [{"FuelA": target_a, "preference": 2, "exclusive": True}], 
                   "constraints": request_qty},
-                 {"commodities": {"FuelB": target_b, "preference": 1, "exclusive": True}, 
+                 {"commodities": [{"FuelB": target_b, "preference": 1, "exclusive": True}], 
                   "constraints": request_qty}]
         return ports
 

--- a/source/arche/dre.rst
+++ b/source/arche/dre.rst
@@ -141,13 +141,13 @@ be:
         # a list makes them mutual requests:
         commods = [{"FuelA": target_a, "preference":2}, 
                    {"FuelB": target_b, "preference":1}]
-        port = {"commodities":commods, "constraints":request_qty
+        port = {"commodities":commods, "constraints":request_qty}
 
         # If you want the requests to be exclusive, then you have to indicate 
         # that:
         commods = [{"FuelA": target_a, "preference":2, "exclusive":True}, 
                    {"FuelB": target_b, "preference":1, "exclusive":True}]
-        port = {"commodities":commods, "constraints":request_qty
+        port = {"commodities":commods, "constraints":request_qty}
 
         # lastly, if you need to return many portfolios, simply return a list of
         # portfolio dictionaries! The "preference" and "exclusive" keys are optional

--- a/source/arche/dre.rst
+++ b/source/arche/dre.rst
@@ -79,6 +79,21 @@ be:
       std::set<RequestPortfolio<Material>::Ptr> ports();
       ports.insert(port);
       return ports;
+
+      // To make the request more complex, you can add preferences to 
+      // each request (argument 4), make them exclusive (argument 5), 
+      // and make the requests mutual:
+      std::set<RequestPortfolio<Material>::Ptr> ports;
+      RequestPortfolio<Material>::Ptr port(new RequestPortfolio<Material>());
+      std::vector<Request<Material>*> mreqs; 
+      double prefA = 2;
+      double prefB = 1;
+      Request<Material>* r1 = port->AddRequest(targeta, this, commodA, prefA, true);
+      Request<Material>* r2 = port->AddRequest(targetb, this, commodB, prefB, true);
+      mreqs = {r1, r2}; 
+      port->AddMutualReqs(mreqs);
+      ports.insert(port);
+      return ports;
     }
 
 **Python:**

--- a/source/arche/dre.rst
+++ b/source/arche/dre.rst
@@ -116,7 +116,7 @@ be:
         recipe_b = self.context().get_recipe("recipeB")
         target_b = ts.Material.create_untracked(request_qty, recipe_b)
         # commodity mapping to request target
-        commods = {"FuelA": target_a}, {"FuelB": target_b}
+        commods = {"FuelA": target_a, "FuelB": target_b}
 
         # The Python interface allow you to return a few different structures,
         # depending on your needs.  In its simplest form, if you do not not have

--- a/source/arche/dre.rst
+++ b/source/arche/dre.rst
@@ -340,7 +340,7 @@ interface:
 
 .. code-block:: python
 
-    from cyclus.typesystem import ts
+    import cyclus.typesystem as ts
 
     def special_foo_offer(self):
         recipe = self.context.get_recipe("recipe")

--- a/source/arche/dre.rst
+++ b/source/arche/dre.rst
@@ -43,7 +43,7 @@ commodity-resource combination. A constraint provides a constraining value and a
 conversion function that can convert a potential resource into the units of the
 capacity (see :ref:`rrfb` for a more detailed example).
 
-For example, consider a facility of type ``FooFac`` that needs 5 kg fuel,
+For example, consider a facility of type ``FooFac`` that needs 10 kg fuel,
 where the fuel is represented by a ``Material`` resource. It knows of two commodities in
 the simulation that meet its demand, ``FuelA`` and ``FuelB``, and it prefers
 ``FuelA`` over ``FuelB``. A valid get material request implementation would then
@@ -96,11 +96,11 @@ be:
         recipe_b = self.context().get_recipe("recipeB")
         target_b = ts.Material.create_untracked(request_qty, recipe_b)
         # commodity mapping to request target
-        commods = {"FuelA": target_a, "FuelB": target_b}
+        commods = {"FuelA": target_a}, {"FuelB": target_b}
 
         # The Python interface allow you to return a few different structures,
         # depending on your needs.  In its simplest form, if you do not not have
-        # any capacity constraints, you can just return the commoditer mapping!
+        # any capacity constraints, you can just return the commodity mapping!
         return commods
 
         # If you do have a capacity constraint, you need to provide a portfolio
@@ -114,10 +114,26 @@ be:
         port = {"commodities": commods, "constraints": [request_qty, request_qty*2]}
         return port
 
+        # If you want to define multiple commodities as mutual requests, such that 
+        # any of them would meet the request, but one is preferred over the other
+        # you need to add preferences to each commodity. 
+        # The larger value indicates a greater preference:
+        commods = [{"FuelA": target_a, "preference":2}, 
+                   {"FuelB": target_b, "preference":1}]
+        port = {"commodities":commods, "constraints":request_qty
+
+        # If you want the requests to be exclusive, then you have to indicate 
+        # that:
+        commods = [{"FuelA": target_a, "preference":2, "exclusive":True}, 
+                   {"FuelB": target_b, "preference":1, "exclusive":True}]
+        port = {"commodities":commods, "constraints":request_qty
+
         # lastly, if you need to return many portfolios, simply return a list of
-        # portfolio dictionaries!
-        ports = [{"commodities": {"FuelA": target_a}, "constraints": request_qty},
-                 {"commodities": {"FuelB": target_b}, "constraints": request_qty}]
+        # portfolio dictionaries! The "preference" and "exclusive" keys are optional
+        ports = [{"commodities": {"FuelA": target_a, "preference": 2, "exclusive": True}, 
+                  "constraints": request_qty},
+                 {"commodities": {"FuelB": target_b, "preference": 1, "exclusive": True}, 
+                  "constraints": request_qty}]
         return ports
 
 

--- a/source/arche/dynamic_loading.rst
+++ b/source/arche/dynamic_loading.rst
@@ -1,4 +1,5 @@
-Dynamic Loading Overview========================
+Dynamic Loading Overview
+========================
 
 *Dynamic loading* is a term used to describe the action of loading
 libraries at run time. This implies that knowledge of the structure

--- a/source/arche/dynamic_loading.rst
+++ b/source/arche/dynamic_loading.rst
@@ -1,5 +1,7 @@
+.. _dynamic_loading:
+
 Dynamic Loading Overview
-========================
+==========================
 
 *Dynamic loading* is a term used to describe the action of loading
 libraries at run time. This implies that knowledge of the structure

--- a/source/arche/hello_world_py.rst
+++ b/source/arche/hello_world_py.rst
@@ -29,7 +29,7 @@ And that is it! The above is a fully-functional |Cyclus| facility.
 
 ------------
 
-Let's now change the behavior of the MyFacility's ``tick()`` and
+Let's now change the behavior of the ``MyFacility``'s ``tick()`` and
 ``tock()`` methods to print "Hello" and "World" respectively.
 
 **proj/agents.py:**
@@ -48,12 +48,12 @@ Let's now change the behavior of the MyFacility's ``tick()`` and
             print("World!")
 
 
-Now that we have altered the behavior of the TutorialFacility, reinstall the project
+Now that we have altered the behavior of ``MyFacility``, reinstall the project
 so that it is available to cyclus.
 
 ------------
 
-You can refer to this facilty in a |cyclus| input file by using the Python package and
+You can refer to this facility in a |cyclus| input file by using the Python package and
 module name in the lib section of the archetypes spec, like you would write it if you
 were importing a module.  The class name goes in the
 name section of the spec.

--- a/source/arche/tutorial_py/index.rst
+++ b/source/arche/tutorial_py/index.rst
@@ -7,9 +7,9 @@ vocabulary of Cyclus.  We also assume that the learner has a Github account.
 
 Overview
 ---------
-Through this tutorial, we will transform a copy of the Cycstub repository into
+Through this tutorial, we will develop 
 an open source Cyclus archetype module that includes an archetype to simulate
-a very simple interim storage facility, named "Storage".  Ultimately, this
+a very simple interim storage facility, named ``Storage``.  Ultimately, this
 facility will have the following characteristics, all definable by the user:
 
 * a fixed rate at which it can transfer material

--- a/source/arche/tutorial_py/setup.rst
+++ b/source/arche/tutorial_py/setup.rst
@@ -73,7 +73,7 @@ Now we can install the tutorial project via,
     ~/tutorial $ python setup.py install --user
 
 
-Let's now make an exmaple input file in a special ``input`` directory:
+Let's now make an example input file in a special ``input`` directory:
 
 .. code-block:: console
 
@@ -109,7 +109,7 @@ Now open up the ``input/storage.`` input file and edit it to look like:
     }
 
 
-Test the input file by running Cyclus:
+Test the input file by running |Cyclus|:
 
 .. code-block:: console
 

--- a/source/arche/tutorial_py/state_var.rst
+++ b/source/arche/tutorial_py/state_var.rst
@@ -73,7 +73,7 @@ stored and the input/output commodity names.
 
 Re-innstall the Modified Module
 ---------------------------------------
-To reinstall this module, just issue the same ``setupy.py`` command as before:
+To reinstall this module, just issue the same ``setup.py`` command as before:
 
 .. code-block:: console
 
@@ -128,7 +128,7 @@ The simulation now fails because it does not match the schema. You can view the 
     ~/tutorial $ cyclus --agent-schema :tut.agents:Storage
 
 Notice that you were able to take advantage of the input file validation simply by using
-the special typesystem class attributes .
+the special ``typesystem`` class attributes.
 
 Our failed cyclus simulation produced an output file that will need to be deleted.
 

--- a/source/arche/tutorial_py/toolkit.rst
+++ b/source/arche/tutorial_py/toolkit.rst
@@ -51,7 +51,7 @@ This creates a state variable named ``inventory`` that is based on the
 ``ResBuf`` class.  We'll explain how buffers
 work in just a moment.  A ResBuf object and its ``ts.Inventory`` state var has special
 handling by the Python ``Agent`` class from which ``Facility`` inherits. It will not appear
-in the schema and therefore will not appear in the Cyclus UI either.
+in the schema.
 
 Next, add two additional buffers:
 

--- a/source/arche/tutorial_py/toolkit.rst
+++ b/source/arche/tutorial_py/toolkit.rst
@@ -26,7 +26,7 @@ Add State Variables and Resource Buffers
 All state variable additions should be included in ``~/tutorial/tut/agents.py`` below the
 other state variables added previously in this tutorial.
 
-A ``ResBuf`` is available as a data type in the typesystem. However, to use it
+A ``ResBuf`` is available as a data type in the ``typesystem``. However, to use it
 as a state variable, so we instead have to use the ``ResBufMaterialInv`` or
 ``RefBufProductInv`` classes. These inventories should be added below the other state
 variables we have already applied to the storage class.
@@ -51,7 +51,7 @@ This creates a state variable named ``inventory`` that is based on the
 ``ResBuf`` class.  We'll explain how buffers
 work in just a moment.  A ResBuf object and its ``ts.Inventory`` state var has special
 handling by the Python ``Agent`` class from which ``Facility`` inherits. It will not appear
-in the schema and therefore will not appear in the Cycic UI either.
+in the schema and therefore will not appear in the Cyclus UI either.
 
 Next, add two additional buffers:
 
@@ -167,7 +167,7 @@ shown below.
 Buffer Transfer Logic
 ++++++++++++++++++++++++++++++++
 The job of the ``Storage`` archetype developer is to determine and implement
-the logic related to transfering material between the input and output buffers
+the logic related to transferring material between the input and output buffers
 and the middle inventory buffer. Two rules govern buffer transfer logic
 in this model:
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -51,6 +51,8 @@ extensions = ['sphinx.ext.mathjax', 'sphinx.ext.autodoc',
               'cyclusagent', 'cloud_sptheme.ext.table_styling',
               'sphinxcontrib.bibtex']
 
+bibtex_bibfiles = ['cite/pubs.bib', 'cep/cep-0002-1.bib', 'cep/cep-0004-1.bib', 'cep/cep-0018-1.bib', 'cep/cep-0020-1.bib']
+
 numpydoc_show_class_members = False
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/cyclusagent.py
+++ b/source/cyclusagent.py
@@ -15,7 +15,8 @@ import textwrap
 import warnings
 import subprocess
 import xml.dom.minidom
-from collections import OrderedDict, Mapping, Sequence
+from collections import OrderedDict
+from collections.abc import Mapping, Sequence
 
 try:
     import simplejson as json

--- a/source/numpydoc/numpydoc.py
+++ b/source/numpydoc/numpydoc.py
@@ -26,7 +26,6 @@ if sphinx.__version__ < '1.0.1':
     raise RuntimeError("Sphinx 1.0.1 or newer is required")
 
 from .docscrape_sphinx import get_doc_object, SphinxDocString
-from sphinx.util.compat import Directive
 
 if sys.version_info[0] >= 3:
     sixu = lambda s: s

--- a/source/user/install.rst
+++ b/source/user/install.rst
@@ -60,8 +60,6 @@ will identify the best approach for you.
 2. Run Cyclus with a Sample XML File
 -------------------------------------
 
-(Cyclist users skip this step)
-
 Try running |Cyclus| for yourself. The result will be a :doc:`database <dbdoc>` named cyclus.sqlite.  Use the drop down menu to load the sqlite file into Cyclist for data visualization, or use your favorite sqlite browser to peruse.
 
 .. code-block:: bash


### PR DESCRIPTION
This PR reflects changes made in [Cyclus PR #1594](https://github.com/cyclus/cyclus/pull/1594) to add some functionality to the Python API for creating material requests. There are also some small typo fixes on a few other pages around the site. 

This should *not* be merged until after Cyclus PR #1594 is merged. 