### PR TITLE
Fix commit in gh-publish-only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ gh-publish-only:
 	rsync -a $(BUILDDIR)/.* .
 	git add -f `(cd $(BUILDDIR); find . -type f; cd ..)`
 	rm -rf  $(BUILDDIR)
-	git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -1 --pretty=short --abbrev-commit`" && git push --force $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
+	git commit -m "Generated $(GH_PUBLISH_BRANCH) for `git log $(GH_SOURCE_BRANCH) -- -1 --pretty=short --abbrev-commit`" && git push --force $(GH_UPSTREAM_REPO) $(GH_PUBLISH_BRANCH)
 	git checkout $(GH_SOURCE_BRANCH)
 
 gh-publish:

--- a/source/cyclusagent.py
+++ b/source/cyclusagent.py
@@ -25,8 +25,6 @@ except ImportError:
 from docutils import nodes
 from docutils.parsers.rst import Directive
 from docutils.parsers.rst import directives
-#from docutils.parsers.rst.roles import set_classes
-#from docutils.transforms import misc
 from docutils.statemachine import ViewList
 
 from sphinx.util.nodes import nested_parse_with_titles


### PR DESCRIPTION
When trying to publish changes made in from the last few PRs merged, I got an error message that 
```
git commit -m "Generated master for `git log source -1 --pretty=short --abbrev-commit`" && git push --force upstream master
fatal: ambiguous argument 'source': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

This change should fix this error, removing the ambiguity in the source branch and the source directory and allow us to publish the changes. 