### PR TITLE
Third-party archetype list update

### DIFF
--- a/source/user/index.rst
+++ b/source/user/index.rst
@@ -113,17 +113,9 @@ evaluating their suitability.
 
 - `:mbmore:RandomEnrich
   <https://github.com/mbmcgarry/mbmore/blob/master/src/RandomEnrich.h#242>`_
-  Based on cycamore enrichment facility, it can have variable tails assay,
-  and bidding behavior can be set to occur at Every X timestep or at Random
-  timesteps.
 
 - `:mbmore:RandomSink
   <https://github.com/mbmcgarry/mbmore/blob/master/src/RandomSink.h#L78>`_
-  Based on cycamore sink facility, it can accept multiple recipes, has
-  modifiable material preference, material request behavior can be set,
-  trading can be suppressed before a specified timestep, material requests
-  can occur at Every X timestep or at Random timesteps, and quantity
-  requested can be varied using a Gaussian distribution function.
 
 **rwc Archetypes** (https://github.com/rwcarlsen/rwc-archetypes)
     This is a collection of miscellaneous archetypes made by Robert Carlsen to
@@ -131,40 +123,18 @@ evaluating their suitability.
 
 - `:rwc:LookInst
   <https://github.com/rwcarlsen/rwc-archetypes/blob/master/look_inst.h>`_
-  This archetype allows the user to specify an arbitrary power capacity
-  time series that the institution will automatically deploy power
-  generating facilities (of multiple types) to match. It uses a look-ahead
-  mechanism to see if its chosen deployments were not "good" and adjusts
-  its deployment decisions accordingly. This archetype currently requires
-  rwcarlsen/cyclus#restart branch of Cyclus to work.
 
 - `:rwc:FleetReactor
   <https://github.com/rwcarlsen/rwc-archetypes/blob/master/fleet_reactor.h>`_
-  This reactor models an entire reactor fleet as a single, homogenous
-  unit.  Like the Cycamore reactor, it just uses static, user-specified
-  compositions for fresh and spent fuel. Refueling is incremental -
-  occuring every time step. It is approximately a continuous flow fleet
-  model much like the way system-dynamics simulators represent facilities.
-  It "pretends" to be many reactors to the Cyclus kernel - allowing other
-  agents to deploy/decommission single-reactor units, but these
-  single-reactors just adjust the size/capacity of the homogenous fleet.
 
 - `:rwc:PatternSink
   <https://github.com/rwcarlsen/rwc-archetypes/blob/master/pattern_sink.h>`_
-  Pattern sink is identical to the Cycamore sink facility except it has an
-  additional parameter that allows the user to control the frequency with
-  which the facility requests material - i.e. the user can tell the
-  facility to only request material every Nth time step.
 
 - `:rwc:Storage
   <https://github.com/rwcarlsen/rwc-archetypes/blob/master/storage.h>`_
-  This facility is very similar to the Cycamore storage facility, and was
-  originally created before Cycamore's existed. It has slightly more
-  careful handling of discrete material objects (e.g. not ever splitting
-  them) and is a bit more sophisticated with respect to resource exchange
-  for offering/bidding its inventory. It would be good to use
-  implementation details from this archetype to improve the Cycamore
-  storage archetype.
+
+
+
 
 Visualization & Analysis
 --------------------------

--- a/source/user/index.rst
+++ b/source/user/index.rst
@@ -151,6 +151,16 @@ OpenMCyclus introduces an archetype that couples OpenMC depletion with Cyclus a 
 - `openmcyclus:DepleteReactor<https://github.com/arfc/openmcyclus/blob/main/openmcyclus/DepleteReactor.py>`_
 
 
+**D3ploy**(https://github.com/arfc/d3ploy/)
+A collection of Cyclus manager archetypes for demand driven deployment. The goal of this package is to provide three types of mathematical basis for predicting supply and demand of commodities within Cyclus; Non-optimizing (NO) deterministic optimization (DO), and Stochastic optimization (SO).
+
+- `d3ploy:DemandDrivenDeploymentInst<https://github.com/arfc/d3ploy/blob/master/d3ploy/demand_driven_deployment_inst.py>`_
+
+- `d3ploy:SupplyDrivenDeploymentInst<https://github.com/arfc/d3ploy/blob/master/d3ploy/supply_driven_deployment_inst.py>`_
+
+- `d3ploy:DemandFac<https://github.com/arfc/d3ploy/blob/master/d3ploy/demand_fac.py>`_
+
+
 
 
 

--- a/source/user/index.rst
+++ b/source/user/index.rst
@@ -133,6 +133,14 @@ evaluating their suitability.
 - `:rwc:Storage
   <https://github.com/rwcarlsen/rwc-archetypes/blob/master/storage.h>`_
 
+**Peddler** (https://github.com/ergs/peddler)
+Peddler is a Cyclus Package used to simulate the transport of material from one facility to another.
+
+- `peddler:truck<https://github.com/ergs/peddler/blob/master/peddler/truck.py>`_
+
+- `peddler:reactor<https://github.com/ergs/peddler/blob/master/peddler/reactor.py>_`
+
+
 
 
 

--- a/source/user/index.rst
+++ b/source/user/index.rst
@@ -145,6 +145,12 @@ Peddler is a Cyclus Package used to simulate the transport of material from one 
 A generic nuclear repository model intended to be used within the Cyclus nuclear fuel cycle simulator. It contains a conditioning facility and a nuclear repository model that places spent fuel packages in a repository based on its temperature and the constraints of the repository.
 
 
+**OpenMCyclus**(https://github.com/arfc/openmcyclus/)
+OpenMCyclus introduces an archetype that couples OpenMC depletion with Cyclus a reactor.
+
+- `openmcyclus:DepleteReactor<https://github.com/arfc/openmcyclus/blob/main/openmcyclus/DepleteReactor.py>`_
+
+
 
 
 

--- a/source/user/index.rst
+++ b/source/user/index.rst
@@ -104,18 +104,18 @@ evaluating their suitability.
    develop archetypes that will use ORIGEN calculations to improve the
    estimate of nuclear fuel properties.
 
-**Mbmore Archetypes** (https://github.com/mbmcgarry/mbmore)
+**Mbmore Archetypes** (https://github.com/cnerg/mbmore)
     Facility archetypes that utilize a random number generator to create
     non-deterministic behaviors.  General methods controlling the behavior
     (including random number generation and Gaussian distributions) are defined in
     the `behavior functions
-    <https://github.com/mbmcgarry/mbmore/blob/master/src/behavior_functions.h>`_.
+    <https://github.com/cnerg/mbmore/blob/main/src/behavior_functions.h>`_.
 
 - `:mbmore:RandomEnrich
-  <https://github.com/mbmcgarry/mbmore/blob/master/src/RandomEnrich.h#242>`_
+  <https://github.com/cnerg/mbmore/blob/main/src/RandomEnrich.h>`_
 
 - `:mbmore:RandomSink
-  <https://github.com/mbmcgarry/mbmore/blob/master/src/RandomSink.h#L78>`_
+  <https://github.com/cnerg/mbmore/blob/main/src/RandomSink.h>`_
 
 **rwc Archetypes** (https://github.com/rwcarlsen/rwc-archetypes)
     This is a collection of miscellaneous archetypes made by Robert Carlsen to

--- a/source/user/index.rst
+++ b/source/user/index.rst
@@ -161,7 +161,10 @@ A collection of Cyclus manager archetypes for demand driven deployment. The goal
 - `d3ploy:DemandFac<https://github.com/arfc/d3ploy/blob/master/d3ploy/demand_fac.py>`_
 
 
+**ann_pwr**(https://github.com/jbae11/ann_pwr)
+This Cyclus Reactor module is created to perform varying burnup and enrichment calculations for LWRs using a trained neural network model to predict UNF composition.
 
+- `ann_pwr:ann_pwr<https://github.com/jbae11/ann_pwr/blob/ann_lwr/ann_lwr/ann_lwr.py>`_
 
 
 Visualization & Analysis

--- a/source/user/index.rst
+++ b/source/user/index.rst
@@ -141,6 +141,10 @@ Peddler is a Cyclus Package used to simulate the transport of material from one 
 - `peddler:reactor<https://github.com/ergs/peddler/blob/master/peddler/reactor.py>_`
 
 
+**Cyder**(https://github.com/arfc/cyder)
+A generic nuclear repository model intended to be used within the Cyclus nuclear fuel cycle simulator. It contains a conditioning facility and a nuclear repository model that places spent fuel packages in a repository based on its temperature and the constraints of the repository.
+
+
 
 
 


### PR DESCRIPTION
This PR adds links to the Cyclus user guide for the following third-party archetypes (TPA)s:
* Peddler
* Cyder
* OpenMCyclus
* D3ploy
* ann_pwr

It also removes descriptions of individual archetypes from the previously listed TPAs.

This PR closes #327 