### PR TITLE
change instances of master branch to main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SPHINXOPTS    =
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = ./gh-build
-GIT_BRANCH    = master
+GIT_BRANCH    = main
 GIT_FORK      = cyclus
 
 
@@ -30,10 +30,10 @@ help:
 	@echo "Please use \`make <target>' where <target> is one of"
 	@echo "  gh-preview        to build HTML in directory $BUILDDIR for testing"
 	@echo "  gh-revert         to cleanup HTML build in directory $BUILDDIR after testing"
-	@echo "  gh-publish        to build final version and push from source branch to master branch"
-	@echo "  gh-publish-only   to push from source branch to master branch, assuming already built"
+	@echo "  gh-publish        to build final version and push from source branch to main branch"
+	@echo "  gh-publish-only   to push from source branch to main branch, assuming already built"
 	@echo "  docker-html       to use docker to build HTML in directory $BUILDDIR for testing"
-	@echo "  docker-gh-publish to use docker to build final version and push from source branch to master branch"
+	@echo "  docker-gh-publish to use docker to build final version and push from source branch to main branch"
 	@echo "  serve             build+serve html files using Python's SimpleHTTPServer"
 	@echo "  serve-only        serve pre-built html files using Python's SimpleHTTPServer"
 	@echo "  dirhtml           to make HTML files named index.html in directories"

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ rebuilding this site.
 Sphinx configuration used to build the site.  All direct editing of
 files should be made in the `source` branch.
 
-2. The `master` branch contains the processed and published web
+2. The `main` branch contains the processed and published web
 content that is derived by Sphinx from the `source` branch.  These
 files should not be editted directly.
 
@@ -113,8 +113,8 @@ Best practice for managing a pull request
 1. Synchronize your repository with the upstream repo::
 
    git fetch upstream
-   git checkout master
-   git merge upstream/master
+   git checkout main
+   git merge upstream/main
    git checkout source
    git merge upstream/source
 

--- a/gh-project.mk
+++ b/gh-project.mk
@@ -5,7 +5,7 @@ GH_SOURCE_DIR = source
 # GH_SOURCE_BRANCH = repository branch that contains the source
 GH_SOURCE_BRANCH = source
 # GH_PUBLISH_BRANCH = repository branch that contains the rendered HTML
-GH_PUBLISH_BRANCH = master
+GH_PUBLISH_BRANCH = main
 # GH_UPSTREAM_REPO = repository that contains the rendered HTML
 GH_UPSTREAM_REPO = upstream
 
@@ -13,6 +13,6 @@ GH_UPSTREAM_REPO = upstream
 # Example for a gh-pages project
 #
 # GH_SOURCE_DIR = doc-src
-# GH_SOURCE_BRANCH = master
+# GH_SOURCE_BRANCH = main
 # GH_PUBLISH_BRANCH = gh-pages
 # GH_UPSTREAM_REPO = upstream

--- a/rever.xsh
+++ b/rever.xsh
@@ -30,10 +30,10 @@ $DOCKER_CONDA_DEPS = ['sphinx', 'numpydoc', 'cyclus', 'cycamore', 'cymetric', 'r
 $DOCKER_INSTALL_ENVVARS = {'PYTHONDONTWRITEBYTECODE': "TRUE"}
 $DOCKER_INSTALL_COMMAND = (
     'git clean -fdx && '
-    'curl https://raw.githubusercontent.com/cyclus/cyclus/master/INSTALL.rst -L -o source/user/CYCLUS_INSTALL.rst && '
-    'curl https://raw.githubusercontent.com/cyclus/cyclus/master/DEPENDENCIES.rst -L -o source/user/DEPENDENCIES.rst && '
-    'curl https://raw.githubusercontent.com/cyclus/cycamore/master/INSTALL.rst -L -o source/user/CYCAMORE_INSTALL.rst && '
-    'curl https://raw.githubusercontent.com/cyclus/cycamore/master/DEPENDENCIES.rst -L -o source/user/CYCAMORE_DEPS.rst && '
+    'curl https://raw.githubusercontent.com/cyclus/cyclus/main/INSTALL.rst -L -o source/user/CYCLUS_INSTALL.rst && '
+    'curl https://raw.githubusercontent.com/cyclus/cyclus/main/DEPENDENCIES.rst -L -o source/user/DEPENDENCIES.rst && '
+    'curl https://raw.githubusercontent.com/cyclus/cycamore/main/INSTALL.rst -L -o source/user/CYCAMORE_INSTALL.rst && '
+    'curl https://raw.githubusercontent.com/cyclus/cycamore/main/DEPENDENCIES.rst -L -o source/user/CYCAMORE_DEPS.rst && '
     'cp $(cyclus --install-path)/share/cyclus/dbtypes.json source/astatic/'
 )
 

--- a/source/kernel/build_from_source.rst
+++ b/source/kernel/build_from_source.rst
@@ -45,11 +45,11 @@ For the git uninitiated, one must perform the following steps to acquire |cyclus
 
 Note that each |cyclus| repository has **two** branches:
 
-  * master -- the latest stable release of the library
+  * main -- the latest stable release of the library
   * develop -- the latest working copy that passes all tests
 
 The above branches are synchronized with each other, and should be used in tandem
-(i.e., use master (|Cyclus|) with master (Cycamore) or develop with develop only).
+(i.e., use main (|Cyclus|) with main (Cycamore) or develop with develop only).
 
 .. _`Set Up git`: http://help.github.com/linux-set-up-git/
 

--- a/source/kernel/contributing_to_cyclus.rst
+++ b/source/kernel/contributing_to_cyclus.rst
@@ -38,7 +38,7 @@ only after:
 * Your code has been reviewed by another developer.
 
 Code from the "develop" branch generally must pass even more rigorous checks
-before being integrated into the "master" branch. Hotfixes would be a
+before being integrated into the "main" branch. Hotfixes would be a
 possible exception to this.
 
 Keeping Your Fork Up To Date
@@ -50,11 +50,11 @@ Keeping Your Fork Up To Date
   compilable) progress when we are not yet ready for the code to become
   'production'.
 
-* Keep your own "master" and "develop" branches in sync with the upstream
-  repository's "master" and "develop" branches. The master branch should
+* Keep your own "main" and "develop" branches in sync with the upstream
+  repository's "main" and "develop" branches. The main branch should
   always be the 'stable' or 'production' release of |cyclus|.
 
-   - Pull the most recent history from the upstream repository "master"
+   - Pull the most recent history from the upstream repository "main"
      and/or "develop" branches before you merge changes into your
      corresponding local branch. Consider doing a rebase pull instead of
      a regular pull or 'fetch and merge'.  For example::
@@ -63,7 +63,7 @@ Keeping Your Fork Up To Date
        git pull --rebase upstream develop
 
 * As you do development on topic branches in your own fork, consider
-  rebasing the topic branch onto the "master" and/or "develop"  branches
+  rebasing the topic branch onto the "main" and/or "develop"  branches
   after *pulls* from the upstream repository rather than merging the pulled
   changes into your branch.  This will help maintain a more linear (and clean)
   history.  *Please see caution about rebasing below*.  For example::
@@ -168,7 +168,7 @@ Reviewing a Pull Request
   - Accept the Pull Request
 
     - In general, **every commit** (notice this is not 'every push') to the
-      "develop" and "master" branches should compile and pass tests. This
+      "develop" and "main" branches should compile and pass tests. This
       is guaranteed by using a NON-fast-forward merge during the pull request
       acceptance process.
 

--- a/source/kernel/style_guide.rst
+++ b/source/kernel/style_guide.rst
@@ -26,7 +26,7 @@ documentation by running `make cyclusdoc` instead of `make all` or `make`.
 .. _`Google C++ Style Guide`: http://google-styleguide.googlecode.com/svn/trunk/cppguide.xml
 .. _`Google Python Style Guide`: http://google-styleguide.googlecode.com/svn/trunk/pyguide.html
 .. _`Artistic Style` : http://astyle.sourceforge.net
-.. _`settings` : http://github.com/cyclus/cyclus/blob/master/misc/.astylerc
+.. _`settings` : http://github.com/cyclus/cyclus/blob/main/misc/.astylerc
 .. _`limits and bugs` : https://sourceforge.net/p/astyle/bugs/
 .. _`Cpplint` : http://google-styleguide.googlecode.com/svn/trunk/cpplint/
 .. _`Pylint` : http://www.pylint.org/

--- a/source/numpydoc/numpydoc.py
+++ b/source/numpydoc/numpydoc.py
@@ -12,7 +12,7 @@ It will:
 - Renumber references.
 - Extract the signature from the docstring, if it can't be determined otherwise.
 
-.. [1] https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt
+.. [1] https://github.com/numpy/numpy/blob/main/doc/HOWTO_DOCUMENT.rst.txt
 
 """
 from __future__ import division, absolute_import, print_function

--- a/source/user/tutorial/run_cyclus_native.rst
+++ b/source/user/tutorial/run_cyclus_native.rst
@@ -55,7 +55,7 @@ When your simulation has finished, a file of the name ``tutorial_singlerx.sqlite
 will be in your file folder. Your Jupyter Notebook can then be used with 
 `Cymetric <https://fuelcycle.org/user/cymetric/index.html>`_ to analyze your 
 data. Examples of how to use Cymetric can be found in the `GitHub 
-<https://github.com/cyclus/cymetric/tree/master/examples>`_.
+<https://github.com/cyclus/cymetric/tree/main/examples>`_.
 
 
 Backup: Files for Success


### PR DESCRIPTION
This PR changes the instances of `master` branch to `main` branch, now that we have changed the default branch for Cyclus, Cycamore, and Cymetric. This addresses one of the item in #337 