### PR TITLE
Update list of contributors

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -92,44 +92,17 @@ Contact Us
 
 * `Developer Call times <http://dev-call.fuelcycle.org>`_: Fridays at 3:00PM EST
 
+
 Contributors
 ------------
 
-* Robert Carlsen
+You can find our amazing contributors through their GitHub profiles
+* `Cyclus Contributors <https://github.com/cyclus/cyclus/graphs/contributors>`_
 
-* Denia Djokic
+* `Cycamore Contributors <https://github.com/cyclus/cycamore/graphs/contributors>`_
 
-* Royal Elmore
+* `Cymetric Contributors <https://github.com/cyclus/cymetric/graphs/contributors>`_.
 
-* Robert Flanagan
-
-* `Matthew Gidden <http://mattgidden.com/>`_
-
-* Ryan Hodge
-
-* `Kathryn (Katy) Huff <http://katyhuff.github.io/>`_
-
-* Jenny Littell
-
-* `Meghan McGarry <http://cnerg.github.io/people/mcgarry.html>`_
-
-* `Baptiste Mouginot <http://cnerg.github.com/people/bam.html>`_
-
-* `Arrielle Opotowsky <http://cnerg.github.io/people/opotowsky.html>`_
-
-* Olzhas Rakhimov
-
-* `Anthony Scopatz <http://scopatz.com/>`_
-
-* Steve Skutnik
-
-* Zach Welch
-
-* `Paul Wilson <http://cnerg.github.io/people/pphw.html>`_
-
-* John Xia
-
-* Teddy Bae
 
 Acknowledgments
 ----------------

--- a/source/index.rst
+++ b/source/index.rst
@@ -96,7 +96,7 @@ Contact Us
 Contributors
 ------------
 
-You can find our amazing contributors through their GitHub profiles
+You can find our amazing contributors through their GitHub contributions for each of the projects:
 * `Cyclus Contributors <https://github.com/cyclus/cyclus/graphs/contributors>`_
 
 * `Cycamore Contributors <https://github.com/cyclus/cycamore/graphs/contributors>`_


### PR DESCRIPTION
This PR changes the explicit list of contributors to links to Cyclus, Cymetric, and Cycamore GitHub contributors.