### PR TITLE
Remove weekly meeting information

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -90,7 +90,6 @@ Contact Us
 
 * `Developers' mailing list and forum <https://groups.google.com/forum/#!forum/cyclus-dev>`_
 
-* `Developer Call times <http://dev-call.fuelcycle.org>`_: Fridays at 3:00PM EST
 
 Contributors
 ------------


### PR DESCRIPTION
This PR removes the zoom link and weekly meeting time from contact us section of index.