### PR TITLE
Publish site via GitHub Actions

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -21,16 +21,13 @@ jobs:
         run: |
             make docker-html
 
-      - name: debug
-        run: |
-            ls -l
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
             path: gh-build
 
   deploy:
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/source' }}
     runs-on: ubuntu-latest
     needs: build-and-upload
 

--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -1,0 +1,48 @@
+name: Build and Publish Site
+
+on:
+  # allows us to run workflows manually
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Checkout cyclus.github.com
+        uses: actions/checkout@v4
+
+      - name: Build Site
+        run: |
+            make docker-html
+
+      - name: debug
+        run: |
+            ls -l
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+            path: gh-build
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build-and-upload
+
+    permissions:
+        pages: write
+        id-token: write  
+    
+    environment:
+        name: github-pages
+        url: ${{ steps.deployment.outputs.page_url }}
+ 
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,8 @@ gh-publish:
 	make gh-publish-only
 
 docker-gh-preview docker-html:
-	docker run -w /cyclus.github.com -v $(PWD):/cyclus.github.com cyclus/fuelcycle.org-deps bash -c "make gh-preview && chmod -R 777 $(BUILDDIR)"
+	docker build -f docker/fuelcycle.org-deps/Dockerfile -t fuelcycle.org-deps .
+	docker run -w /cyclus.github.com -v $(PWD):/cyclus.github.com fuelcycle.org-deps bash -c "make gh-preview && chmod -R 777 $(BUILDDIR)"
 
 docker-gh-publish:
 	make clean

--- a/docker/fuelcycle.org-deps/Dockerfile
+++ b/docker/fuelcycle.org-deps/Dockerfile
@@ -1,9 +1,7 @@
 
-FROM cyclus/cymetric
+FROM ghcr.io/cyclus/cymetric_22.04_apt/cymetric:latest
 
 RUN apt-get update
-RUN apt-get install -y --force-yes wget
-RUN apt-get install -y --force-yes python3-pip
-RUN pip3 install sphinx sphinxcontrib-bibtex
-RUN pip3 install cloud-sptheme==1.6
+RUN apt-get install -y --force-yes wget python3-pip
+RUN python -m pip install sphinx sphinxcontrib-bibtex cloud-sptheme==1.6
 

--- a/docker/fuelcycle.org-deps/Dockerfile
+++ b/docker/fuelcycle.org-deps/Dockerfile
@@ -3,5 +3,5 @@ FROM ghcr.io/cyclus/cymetric_22.04_apt/cymetric:latest
 
 RUN apt-get update
 RUN apt-get install -y --force-yes wget python3-pip
-RUN python -m pip install sphinx sphinxcontrib-bibtex cloud-sptheme==1.6
+RUN python -m pip install sphinx sphinxcontrib-bibtex cloud-sptheme
 


### PR DESCRIPTION
Closes #344.   Instead of maintaining a `main` branch to publish the site this will publish the site via a GitHub workflow on any merge to `source`.  Attempting to follow best practices outlined in [GitHub documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#creating-a-custom-github-actions-workflow-to-publish-your-site).