### PR TITLE
Fix CEP 29 render

### DIFF
--- a/source/cep/cep0.rst
+++ b/source/cep/cep0.rst
@@ -66,7 +66,7 @@ Index
     SA - 25 - Preference Adjustment Process - Gidden <cep25>
     SD - 26 - Generalize the DRE to Optimize Multiple Metrics - Flanagan, Scopatz <cep26>
     SA - 27 - Toolkit Capabilities Injection into an Archetype - Mouginot <cep27>
-    SD - 29 - Packaging of Materials
+    SD - 29 - Packaging of Materials - Mummah <cep29>
 
 Key
 ---


### PR DESCRIPTION
When CEP 29 was added in PR #335, it was missing a link to the `source/cep/cep29.rst` file so it didn't render correctly on `source/cep/cep0.rst`. This issue was identified as part of #347, and this PR fixes it. 