### PR TITLE
Update publication lists

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -52,7 +52,12 @@ extensions = ['sphinx.ext.mathjax', 'sphinx.ext.autodoc',
               'cyclusagent', 'cloud_sptheme.ext.table_styling',
               'sphinxcontrib.bibtex']
 
-bibtex_bibfiles = ['cite/pubs.bib', 'cep/cep-0002-1.bib', 'cep/cep-0004-1.bib', 'cep/cep-0018-1.bib', 'cep/cep-0020-1.bib']
+bibtex_bibfiles = ['cite/pubs.bib', 
+                   'cep/cep-0002-1.bib', 
+                   'cep/cep-0004-1.bib', 
+                   'cep/cep-0018-1.bib', 
+                   'cep/cep-0020-1.bib',
+                   'cite/citecyc.bib']
 
 numpydoc_show_class_members = False
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -57,7 +57,9 @@ bibtex_bibfiles = ['cite/pubs.bib',
                    'cep/cep-0004-1.bib', 
                    'cep/cep-0018-1.bib', 
                    'cep/cep-0020-1.bib',
-                   'cite/citecyc.bib']
+                   'cite/citecyc.bib',
+                   'newsletters/pubsmay2018.bib',
+                   'newsletters/pubsoct2017.bib']
 
 numpydoc_show_class_members = False
 


### PR DESCRIPTION
This PR updates some of the publications listed on the website. Currently, the only change is to add the `source/cite/citecyc.bib` file to the bibtext_bibfiles list in `source/conf.py` so that the publications about difference Cyclus versions appears. This fixes one of the items identified in #337.

@nuclearkatie also mentioned in #337 an item to update this list. Were there any specific publications you had in mind? The lists on the website seem to be focused on the core of Cyclus, and not as much on applications. Do we have any newer publications that fit this bill? I think expanding this list to publications that just use Cyclus will be burdensome to maintain, but I'm open to ideas.  