### PR TITLE
Fix numbering issues in `user/install_binary.rst`

### DIFF
--- a/source/user/install_binary.rst
+++ b/source/user/install_binary.rst
@@ -18,6 +18,8 @@ Installing |Cyclus| with Binaries
    :start-after: .. website_include_deb_start
    :end-before: .. website_include_deb_end
 
+At this point |Cyclus| should be successfully installed on your system and you are ready to install Cycamore.
+
 #. Download the latest Cycamore Debian installation package `here
    <https://github.com/cyclus/cycamore/releases/latest>`_. You can
    download previous/different version `here <https://github.com/cyclus/cycamore/releases>`_.

--- a/source/user/install_binary.rst
+++ b/source/user/install_binary.rst
@@ -12,21 +12,7 @@ Installing |Cyclus| with Binaries
    :start-after: .. website_include_conda_start
    :end-before: .. website_include_conda_end
 
-
-#. Once you have conda installed, installing |Cyclus| and Cycamore is
-   straightforward. If you are having issues with certificate verification
-   you may install using the second set of commands to fix these issues. 
-
-   .. code-block:: bash
-
-      $ conda install -c conda-forge cycamore
-
-   .. code-block:: bash
-
-      $ conda config --set ssl_verify false
-      $ conda install -c conda-forge cycamore
-
-#.  .. include:: unit_test.rst
+.. include:: unit_test.rst
 
 .. include:: CYCAMORE_DEPS.rst
    :start-after: .. website_include_deb_start


### PR DESCRIPTION
This should be considered along with cycamore PR [#595](https://github.com/cyclus/cycamore/pull/595).  I moved some of this information to `DEPENDENCIES.rst` in the cycamore repo so that the numbering looks better.

@abachma2 you're more than welcome to build the site locally with the two PRs, I've attached what I'm seeing locally:
![image](https://github.com/cyclus/cyclus.github.com/assets/79653949/d28f69e4-6177-4658-80c1-10fa47448e05)




