### PR TITLE
Deprecate `ResourceBuff` 

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,5 +2,5 @@ FROM ghcr.io/cyclus/cymetric_22.04_apt/cymetric:latest
 
 RUN apt-get update
 RUN apt-get install -y --force-yes wget python3-pip
-RUN python -m pip install sphinx sphinxcontrib-bibtex cloud-sptheme
+RUN python3 -m pip install sphinx sphinxcontrib-bibtex cloud-sptheme
 

--- a/source/arche/toolkit.rst
+++ b/source/arche/toolkit.rst
@@ -6,10 +6,6 @@ Currently in an experimental state, the |cyclus| toolkit aims to provide
 functionality relevant to a variety of :term:`archetypes <archetype>` that do
 not belong strictly in the :term:`cyclus kernel`.
 
-.. note::
-
-    ResourceBuff has been deprecated in favor of ``ResBuf``.
-
 ResBuf
 ++++++++++++
 The ``cyclus::toolkit::ResBuf`` (C++) or ``cyclus.typesystem.ResBuf`` (Python) class
@@ -21,6 +17,10 @@ for proper persistence and intiialization of the buffer.  For this to work,
 you must annotate the buffer member variable with a Cyclus pre-processor
 :ref:`pragma <pragma-cyclus-var>` (C++) or set a class attribute (Python)
 in one of the following ways:
+
+.. note::
+
+    ``ResourceBuff`` has been deprecated in favor of ``ResBuf``.
 
 **C++:**
 

--- a/source/arche/toolkit.rst
+++ b/source/arche/toolkit.rst
@@ -6,66 +6,9 @@ Currently in an experimental state, the |cyclus| toolkit aims to provide
 functionality relevant to a variety of :term:`archetypes <archetype>` that do
 not belong strictly in the :term:`cyclus kernel`.
 
-ResourceBuff
-++++++++++++
-.. warning::
+.. note::
 
-    ResourceBuff will soon be deprecated in favor of ``ResBuf``.
-
-The ``cyclus::toolkit::ResourceBuff`` (C++) or ``cyclus.typesystem.ResourceBuff`` (Python)
-class provides provides a canonical
-methodology for dealing with collections of ``Resources``.
-:term:`Archetypes <archetype>` in both |cyclus| and Cycamore make use of this
-class.  ``ResourceBuffs`` are usually used as member variables of
-archetypes.  The |Cyclus| preprocessor (C++) or |Cyclus| agents (Python) have special
-handling for ``ResourceBuff``
-as it can generate all needed code for proper persistence and intiialization
-of the buffer. For this to work, you must annotate the buffer member variable
-with a Cyclus pre-processor :ref:`pragma <pragma-cyclus-var>` (C++) or have a
-special ``ResourceBuffInv`` class attribute (Python) in one of the
-following ways:
-
-**C++:**
-
-.. code-block:: c++
-
-    // Option 1: minimum required annotation
-    #pragma cyclus var {}
-    cyclus::toolkit::ResourceBuff mybuf;
-
-    // Option 2: you can set a specify buffer capacity
-    #pragma cyclus var {'capacity': 245.6}
-    cyclus::toolkit::ResourceBuff mybuf;
-
-    // Option 3: you can reference another annotated member variable's value
-    // as the capacity
-    #pragma cyclus var {}
-    double buf_cap;
-    #pragma cyclus var {'capacity': 'buf_cap'}
-    cyclus::toolkit::ResourceBuff mybuf;
-
-**Python:**
-
-.. code-block:: python
-
-    from cyclus.agents import Facility
-    import cyclus.typesystem as ts
-
-    class MyFacility(Facility):
-        # Option 1: minimum required class attribute
-        mybuf = ts.ResourceBuffInv()
-
-        # Option 2: you can set a specify buffer capacity
-        mybuf = ts.ResourceBuffInv(capacity=245.6)
-
-        # Option 3: you can reference another annotated member variable's value
-        # as the capacity
-        buf_cap = ts.Double()
-        mybuf = ts.ResourceBuffInv(capacity='buf_cap')
-
-You can read the `ResourceBuff API documentation
-<http://fuelcycle.org/cyclus/api/classcyclus_1_1toolkit_1_1ResourceBuff.html>`_ for
-more details on how to use the buffer.
+    ResourceBuff has been deprecated in favor of ``ResBuf``.
 
 ResBuf
 ++++++++++++

--- a/source/cyclusagent.py
+++ b/source/cyclusagent.py
@@ -46,7 +46,6 @@ elif sys.version_info[0] >= 3:
 def contains_resbuf(type_str):
     bufs = ('cyclus::toolkit::ResBuf',
             'cyclus::toolkit::ResMap',
-            'cyclus::toolkit::ResourceBuff',
             'cyclus::toolkit::TotalInvTracker')
     for buf in bufs:
         if buf in type_str:


### PR DESCRIPTION
- Updates the toolkit documentation to reflect the deprecation of `ResourceBuff`
- Updates Dockerfile to use `python3` instead of version agnostic `python`