### PR TITLE
Add docs for new constants

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,3 @@
 FROM ghcr.io/cyclus/cymetric_22.04_conda/cymetric:latest
 
-RUN mamba update -y --all
 RUN mamba install -y sphinx sphinxcontrib-bibtex cloud_sptheme

--- a/source/arche/constants.rst
+++ b/source/arche/constants.rst
@@ -50,6 +50,25 @@ the ``cyclus`` package is in your Python path:
   my_small_value = CY_NEAR_ZERO
   ...
 
+This holds true for |Cyclus| input files: 
+
+.. code-block:: python
+
+  from cyclus.system import CY_LARGE_DOUBLE
+  SIMULATION = { 'simulation': 
+    ...
+    'facility': [
+      { 'config': 
+        { 'Source': 
+          { 'capacity': CY_LARGE_DOUBLE,
+    ...
+
+
+.. warning::
+  Only input files written in Python can access the constants in this way, since the variables are evaluated
+  prior to schema validation.  Any attempt to use them in an XML input file will likely fail schema validation since
+  they will be evaluated as strings instead of the corresponding values in C++/Python.
+
 Using constants with the Cyclus Preprocessor
 --------------------------------------------
 

--- a/source/arche/constants.rst
+++ b/source/arche/constants.rst
@@ -1,0 +1,71 @@
+.. _constants:
+
+Using standard constants in |Cyclus|
+======================================
+
+Cyclus defines a set of constants to help standardize archetype properties and prevent
+unexpected simulation failures.  These constants are determined at build time and may
+depend on your system's architecture (e.g. for maximum integer size).  This set is
+defined twice, with identical values existing in the C++ namespace and Python library.
+The numeric values are as follows:
+
+.. list-table:: Cyclus constant values
+   :widths: 25 25 25
+   :header-rows: 1
+
+   * - Name
+     - Value
+   * - CY_LARGE_INT
+     - 2147483647 (on most 64-bit machines; this should be equal to std::numeric_limits<int>::max())
+   * - CY_LARGE_DOUBLE
+     - 1e299
+   * - CY_NEAR_ZERO
+     - 1e-08
+
+Accessing constants in C++
+--------------------------
+
+The constants are defined in ``cyclus/cyc_limits.h`` and exist in the ``cyclus::`` namespace.  They can be
+included and used as so:
+
+.. code-block:: cpp
+    #include "cyclus.h"
+    ...
+    double my_large_double = cyclus::CY_LARGE_DOUBLE;
+    ...
+
+Accessing constants in Python
+-----------------------------
+
+The constants are defined in the ``cyclus.system`` module and can be imported and used as long as
+the cyclus package is in your Python path:
+
+.. code-block:: python
+    from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+    ...
+    my_small_value = CY_NEAR_ZERO
+    ...
+
+Using constants with the Cyclus Preprocessor
+--------------------------------------------
+
+Many archetype developers utilize the Cyclus Preprocessor and ``#pragma cyclus`` to
+define state variables within an archetype.  The preprocessor allows any arbitrary
+Python code to be executed via ``#pragma cyclus exec``.  Thus one can import the
+set of Python constants into the global namespace that agent annotations are processed,
+and reference them in state variable definitions.  Remember that the object
+following ``#pragma cyclus var`` is evaluated by the Python interpreter, so you can
+treat it as if it were Python code.
+
+.. code-block:: cpp
+    #pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE
+
+    ...
+
+    #pragma cyclus var {"default": CY_LARGE_DOUBLE, \
+                      "tooltip": "sink maximum inventory size", \
+                      "uilabel": "Maximum Inventory", \
+                      "uitype": "range", \
+                      "range": [0.0, CY_LARGE_DOUBLE], \
+                      "doc": "total maximum inventory size of sink facility"}
+    double max_inv_size;

--- a/source/arche/constants.rst
+++ b/source/arche/constants.rst
@@ -1,55 +1,59 @@
 .. _constants:
 
-Using standard constants in |Cyclus|
+|Cyclus| Defined Constants
 ======================================
 
 Cyclus defines a set of constants to help standardize archetype properties and prevent
 unexpected simulation failures.  These constants are determined at build time and may
-depend on your system's architecture (e.g. for maximum integer size).  This set is
-defined twice, with identical values existing in the C++ namespace and Python library.
+depend on your system's architecture (specifically the size of an ``int`` type, in bytes).  
+This set is defined twice, with identical values existing in the C++ namespace and Python library.
 The numeric values are as follows:
 
-.. list-table:: Cyclus constant values
-   :widths: 25 25 25
-   :header-rows: 1
+.. list-table::
+  :width: 100%
+  :widths: 25 75
+  :header-rows: 1
 
-   * - Name
-     - Value
-   * - CY_LARGE_INT
-     - 2147483647 (on most 64-bit machines; this should be equal to std::numeric_limits<int>::max())
-   * - CY_LARGE_DOUBLE
-     - 1e299
-   * - CY_NEAR_ZERO
-     - 1e-08
+  * - Name
+    - Value
+  * - CY_LARGE_INT
+    - | 2147483647 on most 64-bit machines.
+      | This should be equal to ``std::numeric_limits<int>::max()``.
+  * - CY_LARGE_DOUBLE
+    - 1e299
+  * - CY_NEAR_ZERO
+    - 1e-08
 
 Accessing constants in C++
 --------------------------
 
 The constants are defined in ``cyclus/cyc_limits.h`` and exist in the ``cyclus::`` namespace.  They can be
-included and used as so:
+used in this way:
 
 .. code-block:: cpp
-    #include "cyclus.h"
-    ...
-    double my_large_double = cyclus::CY_LARGE_DOUBLE;
-    ...
+
+  #include "cyclus.h"
+  ...
+  int my_large_int = cyclus::CY_LARGE_INT;
+  ...
 
 Accessing constants in Python
 -----------------------------
 
 The constants are defined in the ``cyclus.system`` module and can be imported and used as long as
-the cyclus package is in your Python path:
+the ``cyclus`` package is in your Python path:
 
 .. code-block:: python
-    from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
-    ...
-    my_small_value = CY_NEAR_ZERO
-    ...
+
+  from cyclus.system import CY_LARGE_DOUBLE, CY_LARGE_INT, CY_NEAR_ZERO
+  ...
+  my_small_value = CY_NEAR_ZERO
+  ...
 
 Using constants with the Cyclus Preprocessor
 --------------------------------------------
 
-Many archetype developers utilize the Cyclus Preprocessor and ``#pragma cyclus`` to
+Many archetype developers utilize the :ref:`Cyclus Preprocessor <cycpp>` and ``#pragma cyclus`` to
 define state variables within an archetype.  The preprocessor allows any arbitrary
 Python code to be executed via ``#pragma cyclus exec``.  Thus one can import the
 set of Python constants into the global namespace that agent annotations are processed,
@@ -58,14 +62,15 @@ following ``#pragma cyclus var`` is evaluated by the Python interpreter, so you 
 treat it as if it were Python code.
 
 .. code-block:: cpp
-    #pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE
 
-    ...
+  #pragma cyclus exec from cyclus.system import CY_LARGE_DOUBLE
 
-    #pragma cyclus var {"default": CY_LARGE_DOUBLE, \
-                      "tooltip": "sink maximum inventory size", \
-                      "uilabel": "Maximum Inventory", \
-                      "uitype": "range", \
-                      "range": [0.0, CY_LARGE_DOUBLE], \
-                      "doc": "total maximum inventory size of sink facility"}
-    double max_inv_size;
+  ...
+
+  #pragma cyclus var {"default": CY_LARGE_DOUBLE, \
+                    "tooltip": "sink maximum inventory size", \
+                    "uilabel": "Maximum Inventory", \
+                    "uitype": "range", \
+                    "range": [0.0, CY_LARGE_DOUBLE], \
+                    "doc": "total maximum inventory size of sink facility"}
+  double max_inv_size;

--- a/source/arche/tutorial_cpp/state_var.rst
+++ b/source/arche/tutorial_cpp/state_var.rst
@@ -61,7 +61,7 @@ stored and the input/output commodity names.
 .. note::
     Sometimes you may wish to include numeric values in your state variable definitions,
     such as a default value or range of possible values.  Cyclus provides a set of constants
-    that might be of use, see :ref:`constants` for more information.
+    that might be of use, see :ref:`documentation on standard constants <constants>` for more information.
 
 Build and Install the Modified Module
 ---------------------------------------

--- a/source/arche/tutorial_cpp/state_var.rst
+++ b/source/arche/tutorial_cpp/state_var.rst
@@ -38,7 +38,7 @@ stored and the input/output commodity names.
       "doc": "Minimum amount of time material must be stored", \
       "tooltip": "Minimum amount of time material must be stored", \
       "units": "months", \
-      "uilabel": "Storage Time" \ 
+      "uilabel": "Storage Time" \
     }
     int storage_time;
 
@@ -57,6 +57,11 @@ stored and the input/output commodity names.
      "uitype": "outcommodity", \
     }
     std::string outcommod;
+
+.. note::
+    Sometimes you may wish to include numeric values in your state variable definitions,
+    such as a default value or range of possible values.  Cyclus provides a set of constants
+    that might be of use, see :ref:`constants` for more information.
 
 Build and Install the Modified Module
 ---------------------------------------
@@ -78,33 +83,33 @@ to define your module.  It is missing the new variables.  Try it:
 .. code-block:: console
 
     $ cyclus -v 2 input/storage.xml
-                  :                                                               
-              .CL:CC CC             _Q     _Q  _Q_Q    _Q    _Q              _Q   
-            CC;CCCCCCCC:C;         /_\)   /_\)/_/\\)  /_\)  /_\)            /_\)  
+                  :
+              .CL:CC CC             _Q     _Q  _Q_Q    _Q    _Q              _Q
+            CC;CCCCCCCC:C;         /_\)   /_\)/_/\\)  /_\)  /_\)            /_\)
             CCCCCCCCCCCCCl       __O|/O___O|/O_OO|/O__O|/O__O|/O____________O|/O__
          CCCCCCf     iCCCLCC     /////////////////////////////////////////////////
-         iCCCt  ;;;;;.  CCCC                                                      
-        CCCC  ;;;;;;;;;. CClL.                          c                         
-       CCCC ,;;       ;;: CCCC  ;                   : CCCCi                       
-        CCC ;;         ;;  CC   ;;:                CCC`   `C;                     
-      lCCC ;;              CCCC  ;;;:             :CC .;;. C;   ;    :   ;  :;;   
-      CCCC ;.              CCCC    ;;;,           CC ;    ; Ci  ;    :   ;  :  ;  
-       iCC :;               CC       ;;;,        ;C ;       CC  ;    :   ; .      
-      CCCi ;;               CCC        ;;;.      .C ;       tf  ;    :   ;  ;.    
-      CCC  ;;               CCC          ;;;;;;; fC :       lC  ;    :   ;    ;:  
-       iCf ;;               CC         :;;:      tC ;       CC  ;    :   ;     ;  
-      fCCC :;              LCCf      ;;;:         LC :.  ,: C   ;    ;   ; ;   ;  
-      CCCC  ;;             CCCC    ;;;:           CCi `;;` CC.  ;;;; :;.;.  ; ,;  
-        CCl ;;             CC    ;;;;              CCC    CCL                     
-       tCCC  ;;        ;; CCCL  ;;;                  tCCCCC.                      
-        CCCC  ;;     :;; CCCCf  ;                     ,L                          
-         lCCC   ;;;;;;  CCCL                                                      
-         CCCCCC  :;;  fCCCCC                                                      
-          . CCCC     CCCC .                                                       
-           .CCCCCCCCCCCCCi                                                        
-              iCCCCCLCf                                                           
-               .  C. ,                                                            
-                  :                                                               
+         iCCCt  ;;;;;.  CCCC
+        CCCC  ;;;;;;;;;. CClL.                          c
+       CCCC ,;;       ;;: CCCC  ;                   : CCCCi
+        CCC ;;         ;;  CC   ;;:                CCC`   `C;
+      lCCC ;;              CCCC  ;;;:             :CC .;;. C;   ;    :   ;  :;;
+      CCCC ;.              CCCC    ;;;,           CC ;    ; Ci  ;    :   ;  :  ;
+       iCC :;               CC       ;;;,        ;C ;       CC  ;    :   ; .
+      CCCi ;;               CCC        ;;;.      .C ;       tf  ;    :   ;  ;.
+      CCC  ;;               CCC          ;;;;;;; fC :       lC  ;    :   ;    ;:
+       iCf ;;               CC         :;;:      tC ;       CC  ;    :   ;     ;
+      fCCC :;              LCCf      ;;;:         LC :.  ,: C   ;    ;   ; ;   ;
+      CCCC  ;;             CCCC    ;;;:           CCi `;;` CC.  ;;;; :;.;.  ; ,;
+        CCl ;;             CC    ;;;;              CCC    CCL
+       tCCC  ;;        ;; CCCL  ;;;                  tCCCCC.
+        CCCC  ;;     :;; CCCCf  ;                     ,L
+         lCCC   ;;;;;;  CCCL
+         CCCCCC  :;;  fCCCCC
+          . CCCC     CCCC .
+           .CCCCCCCCCCCCCi
+              iCCCCCLCf
+               .  C. ,
+                  :
     Entity: line 17: element Storage: Relax-NG validity error : Expecting an element throughput, got nothing
     Entity: line 17: element Storage: Relax-NG validity error : Invalid sequence in interleave
     Entity: line 17: element Storage: Relax-NG validity error : Element Storage failed to validate content
@@ -155,33 +160,33 @@ Now we can try it again:
 .. code-block:: console
 
     $ cyclus -v 2 input/storage.xml
-                  :                                                               
-              .CL:CC CC             _Q     _Q  _Q_Q    _Q    _Q              _Q   
-            CC;CCCCCCCC:C;         /_\)   /_\)/_/\\)  /_\)  /_\)            /_\)  
+                  :
+              .CL:CC CC             _Q     _Q  _Q_Q    _Q    _Q              _Q
+            CC;CCCCCCCC:C;         /_\)   /_\)/_/\\)  /_\)  /_\)            /_\)
             CCCCCCCCCCCCCl       __O|/O___O|/O_OO|/O__O|/O__O|/O____________O|/O__
          CCCCCCf     iCCCLCC     /////////////////////////////////////////////////
-         iCCCt  ;;;;;.  CCCC                                                      
-        CCCC  ;;;;;;;;;. CClL.                          c                         
-       CCCC ,;;       ;;: CCCC  ;                   : CCCCi                       
-        CCC ;;         ;;  CC   ;;:                CCC`   `C;                     
-      lCCC ;;              CCCC  ;;;:             :CC .;;. C;   ;    :   ;  :;;   
-      CCCC ;.              CCCC    ;;;,           CC ;    ; Ci  ;    :   ;  :  ;  
-       iCC :;               CC       ;;;,        ;C ;       CC  ;    :   ; .      
-      CCCi ;;               CCC        ;;;.      .C ;       tf  ;    :   ;  ;.    
-      CCC  ;;               CCC          ;;;;;;; fC :       lC  ;    :   ;    ;:  
-       iCf ;;               CC         :;;:      tC ;       CC  ;    :   ;     ;  
-      fCCC :;              LCCf      ;;;:         LC :.  ,: C   ;    ;   ; ;   ;  
-      CCCC  ;;             CCCC    ;;;:           CCi `;;` CC.  ;;;; :;.;.  ; ,;  
-        CCl ;;             CC    ;;;;              CCC    CCL                     
-       tCCC  ;;        ;; CCCL  ;;;                  tCCCCC.                      
-        CCCC  ;;     :;; CCCCf  ;                     ,L                          
-         lCCC   ;;;;;;  CCCL                                                      
-         CCCCCC  :;;  fCCCCC                                                      
-          . CCCC     CCCC .                                                       
-           .CCCCCCCCCCCCCi                                                        
-              iCCCCCLCf                                                           
-               .  C. ,                                                            
-                  :                                                               
+         iCCCt  ;;;;;.  CCCC
+        CCCC  ;;;;;;;;;. CClL.                          c
+       CCCC ,;;       ;;: CCCC  ;                   : CCCCi
+        CCC ;;         ;;  CC   ;;:                CCC`   `C;
+      lCCC ;;              CCCC  ;;;:             :CC .;;. C;   ;    :   ;  :;;
+      CCCC ;.              CCCC    ;;;,           CC ;    ; Ci  ;    :   ;  :  ;
+       iCC :;               CC       ;;;,        ;C ;       CC  ;    :   ; .
+      CCCi ;;               CCC        ;;;.      .C ;       tf  ;    :   ;  ;.
+      CCC  ;;               CCC          ;;;;;;; fC :       lC  ;    :   ;    ;:
+       iCf ;;               CC         :;;:      tC ;       CC  ;    :   ;     ;
+      fCCC :;              LCCf      ;;;:         LC :.  ,: C   ;    ;   ; ;   ;
+      CCCC  ;;             CCCC    ;;;:           CCi `;;` CC.  ;;;; :;.;.  ; ,;
+        CCl ;;             CC    ;;;;              CCC    CCL
+       tCCC  ;;        ;; CCCL  ;;;                  tCCCCC.
+        CCCC  ;;     :;; CCCCf  ;                     ,L
+         lCCC   ;;;;;;  CCCL
+         CCCCCC  :;;  fCCCCC
+          . CCCC     CCCC .
+           .CCCCCCCCCCCCCi
+              iCCCCCLCf
+               .  C. ,
+                  :
     INFO1(core  ):Simulation set to run from start=0 to end=10
     INFO1(core  ):Beginning simulation
     INFO1(tutori):Hello

--- a/source/user/writing_input.rst
+++ b/source/user/writing_input.rst
@@ -115,12 +115,16 @@ contains all data for a simulation.
     # dictionary with a single "simulation" key.
     simulation = {"simulation": {...}}
 
-    # Alternitavely, the simualtion variable can also be a Python function or
+    # Alternatively, the simulation variable can also be a Python function or
     # callable that returns a simulation dictionary. This function should not
     # take any arguments.
     def simulation():
         return {"simulation": {...}}
 
+.. note::
+  Some :ref:`constants <constants>` are provided by |Cyclus| and can be leveraged in Python input files.
+  Keep them in mind when defining near-zero values, or very large integer/double values.  This
+  can help keep your simulation within the constraints of the program and avoid runtime errors.
 
 Although not all sections are required, the following sections may appear in
 any order in the input file:


### PR DESCRIPTION
Closes #380.

I also modified the dockerfile to no longer `mamba update -y --all` because it was updating libraries that cyclus depends on (specifically `libicudata.so` could not be found), rendering cyclus unusable.  I'm not sure if we will run into trouble later on of mamba not being able to find the sphinx packages required for building the site.  I think that the update command might be a remnant of using an apt build (needing to update package indexes in order to find the sphinx packages), and I'm not sure that it's necessary with conda/mamba.