### PR TITLE
Build api docs when building site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,10 @@ gh-preview html:
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)."
 
 docker-gh-preview docker-html:
-	docker build -f docker/Dockerfile -t site-deps .
-	docker run -w /cyclus.github.com -v $(PWD):/cyclus.github.com site-deps bash -c "make gh-preview && chmod -R 777 $(BUILDDIR)"
+	docker build --platform linux/amd64 -f docker/Dockerfile -t site-image --build-arg BUILDDIR=$(BUILDDIR) --progress plain .
+	docker create --platform linux/amd64 --name site-container site-image sleep
+	docker cp site-container:/$(BUILDDIR) $(BUILDDIR)
+	docker rm site-container
 
 serve: html
 	cd $(BUILDDIR) && python -m http.server

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,23 @@
-FROM ghcr.io/cyclus/cymetric_22.04_conda/cymetric:latest
+FROM ghcr.io/cyclus/cymetric_22.04_conda/cymetric:latest AS base-image
+ARG BUILDDIR=gh-preview
 
 RUN mamba install -y sphinx sphinxcontrib-bibtex cloud_sptheme
+
+COPY . /cyclus.github.com
+WORKDIR /cyclus.github.com
+RUN make gh-preview
+
+WORKDIR /cyclus/build
+RUN make cyclusdoc && \
+    mkdir -p /cyclus.github.com/${BUILDDIR}/cyclus/api && \
+    cp -r doc/html/* /cyclus.github.com/${BUILDDIR}/cyclus/api/
+
+WORKDIR /cycamore/build
+RUN make cycamoredoc && \
+    mkdir -p /cyclus.github.com/${BUILDDIR}/cycamore/api && \
+    cp -r doc/html/* /cyclus.github.com/${BUILDDIR}/cycamore/api/
+
+
+FROM scratch
+ARG BUILDDIR=gh-preview  
+COPY --from=base-image /cyclus.github.com/${BUILDDIR} /${BUILDDIR}

--- a/source/atemplates/sidebar.html
+++ b/source/atemplates/sidebar.html
@@ -8,8 +8,8 @@
     <li><a href="/arche/index.html">Archetype Developer Guide</a></li>
     <li><a href="/arche/tutorial_cpp/index.html">Archetype Developer C++ Tutorial</a></li>
     <li><a href="/arche/tutorial_py/index.html">Archetype Developer Python Tutorial</a></li>
-     <li><a href="http://fuelcycle.org/cyclus/api/">Cyclus API Documentation</a></li>
-    <li><a href="http://fuelcycle.org/cycamore/api/">Cycamore API Documentation</a></li>
+    <li><a href="/cyclus/api/">Cyclus API Documentation</a></li>
+    <li><a href="/cycamore/api/">Cycamore API Documentation</a></li>
     <li><a href="/basics/glossary.html">Glossary</a></li>
     <li><a href="mailto:cyclus-users+subscribe@googlegroups.com?subject=Subscribe&body=Send this message to subscribe to the list">Join</a> the
       <a href="https://groups.google.com/forum/#!forum/cyclus-users" target="_blank"><span style="font-variant:small-caps">Cyclus</span> Users</a> mailing list.


### PR DESCRIPTION
Moves the site building action into the docker build, and adds some steps to build the Cyclus and Cycamore api docs in the dockerfile too.

Closes https://github.com/cyclus/cyclus/issues/1732