### PR TITLE
Replace @scopatz in CEP01

### DIFF
--- a/source/cep/cep1.rst
+++ b/source/cep/cep1.rst
@@ -8,7 +8,6 @@ CEP 1 - CEP Purpose and Guidelines
 :Status: Active
 :Type: Process
 :Created: 2013-07-03
-:Updated: 2024-11-27
 
 What is a CEP?
 ==============

--- a/source/cep/cep1.rst
+++ b/source/cep/cep1.rst
@@ -4,10 +4,11 @@ CEP 1 - CEP Purpose and Guidelines
 :CEP: 1
 :Title: CEP Purpose and Guidelines
 :Last-Modified: 2013-07-03
-:Author: Anthony Scopatz
+:Author: Anthony Scopatz, Paul Wilson
 :Status: Active
 :Type: Process
 :Created: 2013-07-03
+:Updated: 2024-11-27
 
 What is a CEP?
 ==============
@@ -66,7 +67,7 @@ CEP Workflow
 
 There are several reference in this CEP to the "BDFP". This acronym stands
 for "Benevolent Dictator for the Proposal." In most cases, it is fairly clear
-who this person is (Paul Wilson or Anthony Scopatz).  It is this persons
+who this person is (Paul Wilson or Katy Huff).  It is this persons
 responsibility to consider the entire |cyclus| ecosystem when deciding whether
 or not to accept a proposal.  Weighted with this burden, their decision
 must be adhered to (dictator status), though they will try to do the right
@@ -82,8 +83,8 @@ changing their status).  See `CEP Editor Responsibilities & Workflow`_ for
 details.  The current editors are:
 
 * Paul Wilson
-* Anthony Scopatz
 * Katy Huff
+* Madicken Munk
 
 CEP editorship is by invitation of the current editors.
 


### PR DESCRIPTION
CEP-01 governs the authorship of Cyclus Enhancement Proposals, conveying special authority to @scopatz (among others).  Given that his career trajectory has moved him away from active Cyclus engagement, this proposes a change to CEP-01 that removes reference to him and includes @munkm as one of the identified editors.

If/when CEP-07 (#296) is reconsidered/approved, it may address the definition of editors.