### PR TITLE
Changed "-" to "_" in Input File Examples in Tutorial

### DIFF
--- a/source/user/tutorial/add_commod_recipe.rst
+++ b/source/user/tutorial/add_commod_recipe.rst
@@ -48,15 +48,15 @@ and provides two bids accordingly.
 Activity: Create fuel commodities (optional)
 +++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-Let's build ``u-ore``, ``fresh-uox``, ``spent-uox``, and ``tails``,
+Let's build ``u_ore``, ``fresh_uox``, ``spent_uox``, and ``tails``,
 the four commodities available for trade in our simulation. Note that
 this part is **optional**, and is only needed if the user wants
 to specify the solution priority of each commodity.
 
-* ``u-ore`` : natural uranium that is mined
+* ``u_ore`` : natural uranium that is mined
 * ``tails`` : waste from the enrichment process
-* ``fresh-uox``: fresh 4.0% enriched Uranium Oxide fuel that enters the reactor
-* ``spent-uox``: spent uranium oxide fuel that leaves the reactor after depletion
+* ``fresh_uox``: fresh 4.0% enriched Uranium Oxide fuel that enters the reactor
+* ``spent_uox``: spent uranium oxide fuel that leaves the reactor after depletion
 
 When |Cyclus| needs
 to know the isotopic composition of a material, it looks at the recipe for that
@@ -93,7 +93,7 @@ where:
 * solution priority: number defining the relative priority for resolution in the dynamic
   resource exchange.
 
- We will model four commodities: u-ore, fresh-uox, spent-uox, and tails.
+ We will model four commodities: u_ore, fresh_uox, spent_uox, and tails.
 
 
 Activity: Building commodities
@@ -105,22 +105,22 @@ template.
 +-------------+-------------+---------------------+
 | Commodity   | Name        | Solution Priority   |
 +=============+=============+=====================+
-| com1        | u-ore       | 1.0                 |
+| com1        | u_ore       | 1.0                 |
 +-------------+-------------+---------------------+
-| com2        | fresh-uox   | 1.0                 |
+| com2        | fresh_uox   | 1.0                 |
 +-------------+-------------+---------------------+
-| com3        | spent-uox   | 1.0                 |
+| com3        | spent_uox   | 1.0                 |
 +-------------+-------------+---------------------+
 | com4        | tails       | 1.0                 |
 +-------------+-------------+---------------------+
 
-1. Let's start with ``u-ore``. In the ``<name>`` line replace ``com1`` with ``u-ore``
+1. Let's start with ``u_ore``. In the ``<name>`` line replace ``com1`` with ``u_ore``
 inside a ``commodity`` block.
 
 .. code-block:: XML
 
       <commodity>
-        <name>u-ore</name>
+        <name>u_ore</name>
       </commodity>
 
 2. In the ``<solution_priority>`` section replace ``val1`` with ``1.0``.
@@ -129,7 +129,7 @@ inside a ``commodity`` block.
 
 
       <commodity>
-        <name>u-ore</name>
+        <name>u_ore</name>
         <solution_priority>1.0</solution_priority>
       </commodity>
 
@@ -140,11 +140,11 @@ inside a ``commodity`` block.
 .. code-block:: XML
 
     <commodity>
-      <name>u-ore</name>
+      <name>u_ore</name>
       <solution_priority>1.0</solution_priority>
     </commodity>
     <commodity>
-      <name>fresh-uox</name>
+      <name>fresh_uox</name>
       <solution_priority>1.0</solution_priority>
     </commodity>
     <commodity>
@@ -152,7 +152,7 @@ inside a ``commodity`` block.
       <solution_priority>1.0</solution_priority>
     </commodity>
     <commodity>
-      <name>spent-uox</name>
+      <name>spent_uox</name>
       <solution_priority>1.0</solution_priority>
     </commodity>
 
@@ -167,14 +167,14 @@ Concept: Recipes
 Most commodities are materials, which have a quantity and an
 isotopic composition.
 Recipes are the isotopic composition of a certain material. For
-example, u-ore has an isotropic composition of 0.711% :math:`^{235}`\ U and
+example, u_ore has an isotropic composition of 0.711% :math:`^{235}`\ U and
 99.284% :math:`^{238}`\ U. The recipe section of a |Cyclus| input file is
 typically located at the end of the input and is of the form:
 
 .. code-block:: XML
 
      <recipe>
-      <name>nat-u</name>
+      <name>nat_u</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -252,7 +252,7 @@ block to signify that this is a recipe and tab in and place the fill
 .. code-block:: XML
 
   <recipe>
-    <name>nat-u</name>
+    <name>nat_u</name>
   </recipe>
 
 2. To signify that the composition of this recipe is in terms of Mass, fill the 
@@ -261,7 +261,7 @@ block to signify that this is a recipe and tab in and place the fill
 .. code-block:: XML
 
   <recipe>
-    <name>nat-u</name>
+    <name>nat_u</name>
     <basis>mass</basis>
   </recipe>
 
@@ -271,7 +271,7 @@ block to signify that this is a recipe and tab in and place the fill
 .. code-block:: XML
 
   <recipe>
-    <name>nat-u</name>
+    <name>nat_u</name>
     <basis>mass</basis>
     <nuclide>
       <id>id1</id>
@@ -285,7 +285,7 @@ fill the composition tag with its mass composition, ``0.00711``.
 .. code-block:: XML
 
   <recipe>
-    <name>nat-u</name>
+    <name>nat_u</name>
     <basis>mass</basis>
     <nuclide>
       <id>92235</id>
@@ -298,7 +298,7 @@ fill the composition tag with its mass composition, ``0.00711``.
 .. code-block:: XML
 
   <recipe>
-    <name>nat-u</name>
+    <name>nat_u</name>
     <basis>mass</basis>
     <nuclide>
       <id>92235</id>
@@ -316,7 +316,7 @@ The recipe section of this tutorial is placed below.
 .. code-block:: XML
 
     <recipe>
-      <name>nat-u</name>
+      <name>nat_u</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -329,7 +329,7 @@ The recipe section of this tutorial is placed below.
     </recipe>
 
     <recipe>
-      <name>fresh-uox</name>
+      <name>fresh_uox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -342,7 +342,7 @@ The recipe section of this tutorial is placed below.
     </recipe>
 
     <recipe>
-      <name>spent-uox</name>
+      <name>spent_uox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -365,13 +365,14 @@ The recipe section of this tutorial is placed below.
 Once complete, append this facility under the commodity section of your input file [#f1]_.
 
 
-Let's take a look at the ``fresh-uox`` fuel recipe:
+Let's take a look at the ``fresh_uox`` fuel recipe (note that ``-`` is an illegal character for
+names in cyclus and ``_`` should be used instead):
 
 .. image:: fuel_com.png
     :align: center
-    :alt: Fuel recipe for fresh-uox
-The recipe name ``fresh-uox`` is specified, as are the isotope nuclide IDs and the 
-corresponding mass fraction of each nuclide. The ``fresh-uox`` is composed of 4% U-235 and 96% U-238.
+    :alt: Fuel recipe for fresh_uox
+The recipe name ``fresh_uox`` is specified, as are the isotope nuclide IDs and the 
+corresponding mass fraction of each nuclide. The ``fresh_uox`` is composed of 4% U-235 and 96% U-238.
 
 .. rubric:: Footnotes
 .. [#f1] The exact order of the sections in a |Cyclus| input file are of minor consequence. The ``control`` sequence must go first, but the other sequences can go in any order that makes sense to the user. The traditional organization  of an input file is: control, archetypes, commodities, facilities,   regions/institutions, and recipes. 

--- a/source/user/tutorial/add_deploy.rst
+++ b/source/user/tutorial/add_deploy.rst
@@ -83,9 +83,9 @@ template.
 +-------------+-------------+---------------------+
 | FuelFab               | 1           | 1         |
 +-------------+-------------+---------------------+
-| 1178MWe BRAIDWOOD-1   | 2           | 1         |
+| 1178MWe BRAIDWOOD_1   | 2           | 1         |
 +-------------+-------------+---------------------+
-| 1000MWe Lightwater-1  | 3           | 1         |
+| 1000MWe LIGHTWATER_1  | 3           | 1         |
 +-------------+-------------+---------------------+
 
 Using the prototype facilities already created, the new institution should
@@ -100,8 +100,8 @@ look like the following:
           <prototypes>
             <val>UraniumMine</val>
             <val>FuelFab</val>
-            <val>1178MWe BRAIDWOOD-1</val>
-            <val>1000We Lightwater-1</val>
+            <val>1178MWe BRAIDWOOD_1</val>
+            <val>1000We LIGHTWATER_1</val>
           </prototypes>
 
           <build_times>
@@ -122,8 +122,8 @@ look like the following:
     </institution>
 
 The above institution will create 1 ``UraniumMine`` and 1 ``FuelFab`` facility on
-time step 1. The next time step will deploy the ``1178MWe BRAIDWOOD-1`` reactor
-prototype. And finally, at time step 3, the ``1000We Lightwater-1`` will be deployed.
+time step 1. The next time step will deploy the ``1178MWe BRAIDWOOD_1`` reactor
+prototype. And finally, at time step 3, the ``1000We LIGHTWATER_1`` will be deployed.
 This institution block goes inside the Region block, with the previously created 
 insitutions blocks. 
 

--- a/source/user/tutorial/add_fab.rst
+++ b/source/user/tutorial/add_fab.rst
@@ -39,12 +39,12 @@ The following configuration will be for a
 MOX fuel fabrication plant that mixes separated 
 plutonium and natural uranium into MOX fuel:
 
-* Filler stream commodity: ``u-ore``
-* Filler stream recipe: ``nat-u``
+* Filler stream commodity: ``u_ore``
+* Filler stream recipe: ``nat_u``
 * Filler stream inventory capacity: 1000 tonnes
-* Fissile stream commodity: Separated-Fissile
+* Fissile stream commodity: Separated_Fissile
 * Fissile stream inventory capacity: 5 tonnes
-* Output Commodity: Fresh-MOX-Fuel
+* Output Commodity: Fresh_MOX_Fuel
 * Maximum Throughput: 2 tonnes/timestep
 * Specturm type: "thermal"
 
@@ -56,13 +56,13 @@ Filling in the template, the input block looks like:
     <name>FuelFab</name>
     <config>
       <FuelFab>
-        <fill_commods> <val>U-ore</val> </fill_commods>
-        <fill_recipe>Nat-U</fill_recipe>
+        <fill_commods> <val>u_ore</val> </fill_commods>
+        <fill_recipe>nat_u</fill_recipe>
         <fill_size>1000000</fill_size>
-        <fiss_commods><val>Separated-Fissile</val></fiss_commods>
+        <fiss_commods><val>Separated_Fissile</val></fiss_commods>
         <fiss_size>5000</fiss_size>
         <spectrum>thermal</spectrum>
-        <outcommod>Fresh-MOX-Fuel</outcommod>
+        <outcommod>Fresh_MOX_Fuel</outcommod>
         <throughput>2000</throughput>
       </FuelFab>
     </config>

--- a/source/user/tutorial/add_proto.rst
+++ b/source/user/tutorial/add_proto.rst
@@ -93,7 +93,7 @@ Archetype and the table below, create the UraniumMine prototype.
 +-----------------------+---------------------------+
 | ``Archetype``         | ``Source``                |
 +-----------------------+---------------------------+
-| ``out_commod``        | ``u-ore``                 |
+| ``out_commod``        | ``u_ore``                 |
 +-----------------------+---------------------------+
 
 1. The template for the Source archetype is of the form:
@@ -110,7 +110,7 @@ Archetype and the table below, create the UraniumMine prototype.
   </facility>
 
 2. Filling in the variables ``name``, ``Archetype``, and ``out_commod`` as 
-``UraniumMine``, ``Source``, and ``fresh-uox`` leads to:
+``UraniumMine``, ``Source``, and ``fresh_uox`` leads to:
 
 .. code-block:: XML
 
@@ -118,7 +118,7 @@ Archetype and the table below, create the UraniumMine prototype.
     <name>UraniumMine</name>
     <config>
       <Source>
-        <outcommod>u-ore</outcommod>
+        <outcommod>u_ore</outcommod>
       </Source>
     </config>
   </facility>
@@ -154,7 +154,7 @@ max_feed_inventory: default = 1e+299, range: [0.0, 1e+299]
 
 .. code-block:: XML
 
-          <max_feed_inventory>1000000</max_feed_inventory 
+          <max_feed_inventory>1000000</max_feed_inventory> 
 
 tails_assay: default=0.003, range: [0.0, 0.003]
   Tails assay from the enrichment process
@@ -193,8 +193,8 @@ swu_capacity: default = 1e+299, range: [0.0, 1e+299]
 
 Activity: Creating the Enrichment Prototype
 +++++++++++++++++++++++++++++++++++++++++++
-The enrichment facility, ``EnrichmentPlant`` will intake the natural ``u-ore`` 
-from ``UraniumMine`` and create ``fresh-uox`` and ``tails`` as its products.
+The enrichment facility, ``EnrichmentPlant`` will intake the natural ``u_ore`` 
+from ``UraniumMine`` and create ``fresh_uox`` and ``tails`` as its products.
 The template for the Enrichment archetype is of the form:
 
 .. code-block:: XML
@@ -221,11 +221,11 @@ Using the template above and the table below, generate the input enrichment faci
 +-------------------------+---------------------------+
 | ``Archetype``           | ``Enrichment``            |
 +-------------------------+---------------------------+
-| ``feed_commod``         | ``u-ore``                 |
+| ``feed_commod``         | ``u_ore``                 |
 +-------------------------+---------------------------+
-| ``feed_recipe``         | ``nat-u``                 |
+| ``feed_recipe``         | ``nat_u``                 |
 +-------------------------+---------------------------+
-| ``product_commod``      | ``fresh-uox``             |
+| ``product_commod``      | ``fresh_uox``             |
 +-------------------------+---------------------------+
 | ``tails_commod``        | ``tails``                 |
 +-------------------------+---------------------------+
@@ -241,9 +241,9 @@ After filling in these variables, your enrichment facility prototype will look l
     <name>EnrichmentPlant</name>
     <config>
       <Enrichment>
-        <feed_commod>u-ore</feed_commod>
-        <feed_recipe>nat-u</feed_recipe>
-        <product_commod>fresh-uox</product_commod>
+        <feed_commod>u_ore</feed_commod>
+        <feed_recipe>nat_u</feed_recipe>
+        <product_commod>fresh_uox</product_commod>
         <tails_commod>tails</tails_commod>
         <max_feed_inventory>1000000</max_feed_inventory>
       </Enrichment>
@@ -354,17 +354,17 @@ Using the template above and the table below, create the Reactor prototype.
 +-----------------------+---------------------------+
 | Variable              | Value                     |
 +=======================+===========================+
-| ``name``              | ``1178MWe BRAIDWOOD-1``   |
+| ``name``              | ``1178MWe BRAIDWOOD_1``   |
 +-----------------------+---------------------------+
 | ``Archetype``         | ``Reactor``               |
 +-----------------------+---------------------------+
-| ``fuel_incommods``    | ``fresh-uox``             |
+| ``fuel_incommods``    | ``fresh_uox``             |
 +-----------------------+---------------------------+
-| ``fuel_inrecipes``    | ``fresh-uox``             |
+| ``fuel_inrecipes``    | ``fresh_uox``             |
 +-----------------------+---------------------------+
-| ``fuel_outcommods``   | ``spent-uox``             |
+| ``fuel_outcommods``   | ``spent_uox``             |
 +-----------------------+---------------------------+
-| ``fuel_outrecipes``   | ``spent-uox``             |
+| ``fuel_outrecipes``   | ``spent_uox``             |
 +-----------------------+---------------------------+
 | ``cycle_time``        | ``18``                    |
 +-----------------------+---------------------------+
@@ -384,13 +384,13 @@ Once completed, your prototype should look like:
 .. code-block:: XML
 
     <facility>
-        <name>1178MWe BRAIDWOOD-1</name>
+        <name>1178MWe BRAIDWOOD_1</name>
         <config>
           <Reactor>
-            <fuel_incommods> <val>fresh-uox</val> </fuel_incommods>
-            <fuel_inrecipes> <val>fresh-uox</val> </fuel_inrecipes>
-            <fuel_outcommods> <val>spent-uox</val> </fuel_outcommods>
-            <fuel_outrecipes> <val>spent-uox</val> </fuel_outrecipes>
+            <fuel_incommods> <val>fresh_uox</val> </fuel_incommods>
+            <fuel_inrecipes> <val>fresh_uox</val> </fuel_inrecipes>
+            <fuel_outcommods> <val>spent_uox</val> </fuel_outcommods>
+            <fuel_outrecipes> <val>spent_uox</val> </fuel_outrecipes>
             <cycle_time>18</cycle_time>
             <refuel_time>1</refuel_time>
             <assem_size>33000</assem_size>
@@ -444,7 +444,7 @@ recipe_name: default=””
 
 .. code-block:: XML
 
-      <recipe_name>[inrecipe]</recipe_name
+      <recipe_name>[inrecipe]</recipe_name>
 
 
 max_inv_size: default=1e+299, range: [0.0, 1e+299]
@@ -463,7 +463,7 @@ capacity: default = 1e+299, range: [0.0, 1e+299]
 
 Activity: Creating the Sink Prototype
 +++++++++++++++++++++++++++++++++++++
-Our sink, ``NuclearRepository``, will store the ``spent-uox`` and ``tails`` after
+Our sink, ``NuclearRepository``, will store the ``spent_uox`` and ``tails`` after
 their use in the fuel cycle. Using the Sink Archetype template and the table below,
 create the UraniumMine prototype.
 
@@ -474,7 +474,7 @@ create the UraniumMine prototype.
 +-------------------------+---------------------------+
 | ``Archetype``           | ``Sink``                  |
 +-------------------------+---------------------------+
-| ``val``                 | ``spent-uox``             |
+| ``val``                 | ``spent_uox``             |
 +-------------------------+---------------------------+
 | ``val``                 | ``tails``                 |
 +-------------------------+---------------------------+
@@ -504,7 +504,7 @@ After filling in these variables, your sink facility prototype will look like:
     <config>
       <Sink>
         <in_commods>
-          <val>spent-uox</val>
+          <val>spent_uox</val>
           <val>tails</val>
         </in_commods>
       </Sink>
@@ -524,7 +524,7 @@ The facility section of your input file should be of the form:
     <name>UraniumMine</name>
     <config>
       <Source>
-        <outcommod>u-ore</outcommod>
+        <outcommod>u_ore</outcommod>
       </Source>
     </config>
   </facility>
@@ -533,9 +533,9 @@ The facility section of your input file should be of the form:
     <name>EnrichmentPlant</name>
     <config>
       <Enrichment>
-        <feed_commod>u-ore</feed_commod>
-        <feed_recipe>nat-u</feed_recipe>
-        <product_commod>fresh-uox</product_commod>
+        <feed_commod>u_ore</feed_commod>
+        <feed_recipe>nat_u</feed_recipe>
+        <product_commod>fresh_uox</product_commod>
         <tails_commod>tails</tails_commod>
         <max_feed_inventory>1000000</max_feed_inventory>
       </Enrichment>
@@ -543,13 +543,13 @@ The facility section of your input file should be of the form:
   </facility>
 
   <facility>
-    <name>1178MWe BRAIDWOOD-1</name>
+    <name>1178MWe BRAIDWOOD_1</name>
     <config>
       <Reactor>
-        <fuel_incommods> <val>fresh-uox</val> </fuel_incommods>
-        <fuel_inrecipes> <val>fresh-uox</val> </fuel_inrecipes>
-        <fuel_outcommods> <val>spent-uox</val> </fuel_outcommods>
-        <fuel_outrecipes> <val>spent-uox</val> </fuel_outrecipes>
+        <fuel_incommods> <val>fresh_uox</val> </fuel_incommods>
+        <fuel_inrecipes> <val>fresh_uox</val> </fuel_inrecipes>
+        <fuel_outcommods> <val>spent_uox</val> </fuel_outcommods>
+        <fuel_outrecipes> <val>spent_uox</val> </fuel_outrecipes>
         <cycle_time>18</cycle_time>
         <refuel_time>1</refuel_time>
         <assem_size>33000</assem_size>
@@ -565,7 +565,7 @@ The facility section of your input file should be of the form:
     <config>
       <Sink>
         <in_commods>
-          <val>spent-uox</val>
+          <val>spent_uox</val>
           <val>tails</val>
         </in_commods>
       </Sink>

--- a/source/user/tutorial/add_reg_inst.rst
+++ b/source/user/tutorial/add_reg_inst.rst
@@ -326,14 +326,14 @@ Activity: Add an extra insitution into the Region
 -------------------------------------------------
 Having multiple insitutions help organize facilities and their affiliation.
 Let's create region, ``USA``, that contains two institutions, ``Exelon`` and ``United States Nuclear``.
-``Exelon`` is the institution that holds the ``1178MWe BRAIDWOOD-1`` reactor and ``United States Nuclear`` holds the ``UraniumMine``, ``EnrichmentPlant``, and ``NuclearRepository``.
+``Exelon`` is the institution that holds the ``1178MWe BRAIDWOOD_1`` reactor and ``United States Nuclear`` holds the ``UraniumMine``, ``EnrichmentPlant``, and ``NuclearRepository``.
 
 .. image:: RIF_tutorial.png
 
 Using the template above and the table below, let's build the region.
 
 1. Since there are two institutions, ``Exelon`` and ``United States Nuclear``, we will split the region into two parts.
-Let's first build the ``Exelon`` institution. This institution has one ``1178MWe BRAIDWOOD-1`` prototype. Using this information we can write this institution as:
+Let's first build the ``Exelon`` institution. This institution has one ``1178MWe BRAIDWOOD_1`` prototype. Using this information we can write this institution as:
 
 .. code-block:: XML
 
@@ -345,7 +345,7 @@ Let's first build the ``Exelon`` institution. This institution has one ``1178MWe
     <institution>
       <initialfacilitylist>
         <entry>
-          <prototype>1178MWe BRAIDWOOD-1</prototype>
+          <prototype>1178MWe BRAIDWOOD_1</prototype>
           <number>1</number>
         </entry>
       </initialfacilitylist>
@@ -392,7 +392,7 @@ Let's first build the ``Exelon`` institution. This institution has one ``1178MWe
     <institution>
       <initialfacilitylist>
         <entry>
-          <prototype>1178MWe BRAIDWOOD-1</prototype>
+          <prototype>1178MWe BRAIDWOOD_1</prototype>
           <number>1</number>
         </entry>
       </initialfacilitylist>

--- a/source/user/tutorial/add_second_reactor.rst
+++ b/source/user/tutorial/add_second_reactor.rst
@@ -2,7 +2,7 @@ Adding a second reactor
 =======================
 
 Simple simulations can easily be expanded into more complex problems. To demonstrate this, 
-we will now add a second reactor, ``1000We Lightwater-1``, to our
+we will now add a second reactor, ``1000We Lightwater_1``, to our
 simulation. This reactor will have a lifetime of 360 months (30 years),
 cycle time of 12 months, assembly size of 30160 kg, and power capacity 1000
 MWe. Using this information, let's construct the facility input section
@@ -17,19 +17,19 @@ prototype.
 +-----------------------+---------------------------+
 | Variable              | Value                     |
 +=======================+===========================+
-| ``name``              | ``1000We Lightwater-1``   |
+| ``name``              | ``1000We Lightwater_1``   |
 +-----------------------+---------------------------+
 | ``lifetime``          | ``360``                   |
 +-----------------------+---------------------------+
 | ``Archetype``         | ``Reactor``               |
 +-----------------------+---------------------------+
-| ``fuel_incommods``    | ``fresh-uox``             |
+| ``fuel_incommods``    | ``fresh_uox``             |
 +-----------------------+---------------------------+
-| ``fuel_inrecipes``    | ``fresh-uox``             |
+| ``fuel_inrecipes``    | ``fresh_uox``             |
 +-----------------------+---------------------------+
-| ``fuel_outcommods``   | ``spent-uox``             |
+| ``fuel_outcommods``   | ``spent_uox``             |
 +-----------------------+---------------------------+
-| ``fuel_outrecipes``   | ``spent-uox``             |
+| ``fuel_outrecipes``   | ``spent_uox``             |
 +-----------------------+---------------------------+
 | ``cycle_time``        | ``12``                    |
 +-----------------------+---------------------------+
@@ -49,14 +49,14 @@ Once complete, your reactor prototype should look like:
 .. code-block:: xml
 
   <facility>
-    <name>1000We Lightwater-1</name>
+    <name>1000We Lightwater_1</name>
     <lifetime>360</lifetime>
     <config>
       <Reactor>
-        <fuel_incommods> <val>fresh-uox</val> </fuel_incommods>
-        <fuel_inrecipes> <val>fresh-uox</val> </fuel_inrecipes>
-        <fuel_outcommods> <val>spent-uox</val> </fuel_outcommods>
-        <fuel_outrecipes> <val>spent-uox</val> </fuel_outrecipes>
+        <fuel_incommods> <val>fresh_uox</val> </fuel_incommods>
+        <fuel_inrecipes> <val>fresh_uox</val> </fuel_inrecipes>
+        <fuel_outcommods> <val>spent_uox</val> </fuel_outcommods>
+        <fuel_outrecipes> <val>spent_uox</val> </fuel_outrecipes>
         <cycle_time>12</cycle_time>
         <refuel_time>1</refuel_time>
         <assem_size>30160</assem_size>
@@ -67,7 +67,7 @@ Once complete, your reactor prototype should look like:
     </config>
   </facility>
 
-Append this prototype right after the ``1178MWe BRAIDWOOD-1`` prototype.
+Append this prototype right after the ``1178MWe BRAIDWOOD_1`` prototype.
 
 Activity: Second reactor Institution
 ++++++++++++++++++++++++++++++++++++
@@ -80,11 +80,11 @@ and add
 .. code-block:: xml
 
   <entry>
-    <prototype>1000We Lightwater-1</prototype>
+    <prototype>1000We Lightwater_1</prototype>
     <number>1</number>
   </entry>
 
-below the ``1178MWe BRAIDWOOD-1`` entry block. The Reactor section
+below the ``1178MWe BRAIDWOOD_1`` entry block. The Reactor section
 of the region block should now look like,
 
 .. code-block:: xml
@@ -97,11 +97,11 @@ of the region block should now look like,
         <institution>
           <initialfacilitylist>
             <entry>
-              <prototype>1178MWe BRAIDWOOD-1</prototype>
+              <prototype>1178MWe BRAIDWOOD_1</prototype>
               <number>1</number>
             </entry>
             <entry>
-              <prototype>1000We Lightwater-1</prototype>
+              <prototype>1000We Lightwater_1</prototype>
               <number>1</number>
             </entry>
           </initialfacilitylist>

--- a/source/user/tutorial/add_sep.rst
+++ b/source/user/tutorial/add_sep.rst
@@ -48,10 +48,10 @@ The following is the input template for ``Cycamore::Separations`` archetype:
 * The maximum feed inventory is the most feed material that we'll have on
   hand: 1000 tonnes.
 * The maximum separations throughout is the size of our plant: 80 tonnes/timestep
-* This simple scenario will have a single output stream: Separated-Fissile
+* This simple scenario will have a single output stream: Separated_Fissile
     * we will hold no more than 5 tonnes of separated material on hand at any time
     * 99% of all Pu (94000) will go into that stream
-* all other material will go to Separated-Waste
+* all other material will go to Separated_Waste
 
 Filling in the template, the input block looks like:
 
@@ -62,8 +62,8 @@ Filling in the template, the input block looks like:
      <config>
        <Separations>
          <feed_commods>
-           <val>spent-uox</val>
-           <val>used-mox</val>
+           <val>spent_uox</val>
+           <val>used_mox</val>
          </feed_commods>
          <feed_commod_prefs>
            <val>1.0</val>
@@ -71,11 +71,11 @@ Filling in the template, the input block looks like:
          </feed_commod_prefs>
          <feedbuf_size>1000E+3_</feedbuf_size>
          <throughput>80e+3</throughput>
-         <leftover_commod>Separated-Waste</leftover_commod>
+         <leftover_commod>Separated_Waste</leftover_commod>
          <leftoverbuf_size>1000e+3</leftoverbuf_size>
          <streams>
            <item>
-             <commod>Separated-Fissile</commod>
+             <commod>Separated_Fissile</commod>
              <info> 
                <buf_size>5e+3</buf_size>
                <efficiencies>

--- a/source/user/tutorial/cyclus_tutorial_recap.rst
+++ b/source/user/tutorial/cyclus_tutorial_recap.rst
@@ -43,11 +43,11 @@ Basic Tutorial Input
         </spec>
       </archetypes>
       <commodity>
-          <name>u-ore</name>
+          <name>u_ore</name>
           <solution_priority>1.0</solution_priority>
         </commodity>
         <commodity>
-          <name>fresh-uox</name>
+          <name>fresh_uox</name>
           <solution_priority>1.0</solution_priority>
         </commodity>
         <commodity>
@@ -55,7 +55,7 @@ Basic Tutorial Input
           <solution_priority>1.0</solution_priority>
         </commodity>
         <commodity>
-          <name>spent-uox</name>
+          <name>spent_uox</name>
           <solution_priority>1.0</solution_priority>
         </commodity>
 
@@ -63,7 +63,7 @@ Basic Tutorial Input
           <name>UraniumMine</name>
           <config>
             <Source>
-              <outcommod>u-ore</outcommod>
+              <outcommod>u_ore</outcommod>
             </Source>
           </config>
         </facility>
@@ -72,9 +72,9 @@ Basic Tutorial Input
           <name>EnrichmentPlant</name>
           <config>
             <Enrichment>
-              <feed_commod>u-ore</feed_commod>
-              <feed_recipe>nat-u</feed_recipe>
-              <product_commod>fresh-uox</product_commod>
+              <feed_commod>u_ore</feed_commod>
+              <feed_recipe>nat_u</feed_recipe>
+              <product_commod>fresh_uox</product_commod>
               <tails_commod>tails</tails_commod>
               <max_feed_inventory>1000000</max_feed_inventory>
             </Enrichment>
@@ -82,13 +82,13 @@ Basic Tutorial Input
         </facility>
 
         <facility>
-          <name>1178MWe BRAIDWOOD-1</name>
+          <name>1178MWe BRAIDWOOD_1</name>
           <config>
             <Reactor>
-              <fuel_incommods> <val>fresh-uox</val> </fuel_incommods>
-              <fuel_inrecipes> <val>fresh-uox</val> </fuel_inrecipes>
-              <fuel_outcommods> <val>spent-uox</val> </fuel_outcommods>
-              <fuel_outrecipes> <val>spent-uox</val> </fuel_outrecipes>
+              <fuel_incommods> <val>fresh_uox</val> </fuel_incommods>
+              <fuel_inrecipes> <val>fresh_uox</val> </fuel_inrecipes>
+              <fuel_outcommods> <val>spent_uox</val> </fuel_outcommods>
+              <fuel_outrecipes> <val>spent_uox</val> </fuel_outrecipes>
               <cycle_time>18</cycle_time>
               <refuel_time>1</refuel_time>
               <assem_size>33000</assem_size>
@@ -104,7 +104,7 @@ Basic Tutorial Input
           <config>
             <Sink>
               <in_commods>
-                <val>spent-uox</val>
+                <val>spent_uox</val>
                 <val>tails</val>
               </in_commods>
             </Sink>
@@ -119,7 +119,7 @@ Basic Tutorial Input
           <institution>
             <initialfacilitylist>
               <entry>
-                <prototype>1178MWe BRAIDWOOD-1</prototype>
+                <prototype>1178MWe BRAIDWOOD_1</prototype>
                 <number>1</number>
               </entry>
               </initialfacilitylist>
@@ -153,7 +153,7 @@ Basic Tutorial Input
 
 
     <recipe>
-      <name>nat-u</name>
+      <name>nat_u</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -166,7 +166,7 @@ Basic Tutorial Input
     </recipe>
 
     <recipe>
-      <name>fresh-uox</name>
+      <name>fresh_uox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -179,7 +179,7 @@ Basic Tutorial Input
     </recipe>
 
     <recipe>
-      <name>spent-uox</name>
+      <name>spent_uox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -242,11 +242,11 @@ Add a Second Reactor Input
         </spec>
       </archetypes>
       <commodity>
-          <name>u-ore</name>
+          <name>u_ore</name>
           <solution_priority>1.0</solution_priority>
         </commodity>
         <commodity>
-          <name>fresh-uox</name>
+          <name>fresh_uox</name>
           <solution_priority>1.0</solution_priority>
         </commodity>
         <commodity>
@@ -254,7 +254,7 @@ Add a Second Reactor Input
           <solution_priority>1.0</solution_priority>
         </commodity>
         <commodity>
-          <name>spent-uox</name>
+          <name>spent_uox</name>
           <solution_priority>1.0</solution_priority>
         </commodity>
 
@@ -262,7 +262,7 @@ Add a Second Reactor Input
           <name>UraniumMine</name>
           <config>
             <Source>
-              <outcommod>u-ore</outcommod>
+              <outcommod>u_ore</outcommod>
             </Source>
           </config>
         </facility>
@@ -271,9 +271,9 @@ Add a Second Reactor Input
           <name>EnrichmentPlant</name>
           <config>
             <Enrichment>
-              <feed_commod>u-ore</feed_commod>
-              <feed_recipe>nat-u</feed_recipe>
-              <product_commod>fresh-uox</product_commod>
+              <feed_commod>u_ore</feed_commod>
+              <feed_recipe>nat_u</feed_recipe>
+              <product_commod>fresh_uox</product_commod>
               <tails_commod>tails</tails_commod>
               <max_feed_inventory>1000000</max_feed_inventory>
             </Enrichment>
@@ -281,13 +281,13 @@ Add a Second Reactor Input
         </facility>
 
         <facility>
-          <name>1178MWe BRAIDWOOD-1</name>
+          <name>1178MWe BRAIDWOOD_1</name>
           <config>
             <Reactor>
-              <fuel_incommods> <val>fresh-uox</val> </fuel_incommods>
-              <fuel_inrecipes> <val>fresh-uox</val> </fuel_inrecipes>
-              <fuel_outcommods> <val>spent-uox</val> </fuel_outcommods>
-              <fuel_outrecipes> <val>spent-uox</val> </fuel_outrecipes>
+              <fuel_incommods> <val>fresh_uox</val> </fuel_incommods>
+              <fuel_inrecipes> <val>fresh_uox</val> </fuel_inrecipes>
+              <fuel_outcommods> <val>spent_uox</val> </fuel_outcommods>
+              <fuel_outrecipes> <val>spent_uox</val> </fuel_outrecipes>
               <cycle_time>18</cycle_time>
               <refuel_time>1</refuel_time>
               <assem_size>33000</assem_size>
@@ -299,14 +299,14 @@ Add a Second Reactor Input
         </facility>
 
         <facility>
-          <name>1000We Lightwater-1</name>
+          <name>1000We LIGHTWATER_1</name>
           <lifetime>360</lifetime>
           <config>
             <Reactor>
-              <fuel_incommods> <val>fresh-uox</val> </fuel_incommods>
-              <fuel_inrecipes> <val>fresh-uox</val> </fuel_inrecipes>
-              <fuel_outcommods> <val>spent-uox</val> </fuel_outcommods>
-              <fuel_outrecipes> <val>spent-uox</val> </fuel_outrecipes>
+              <fuel_incommods> <val>fresh_uox</val> </fuel_incommods>
+              <fuel_inrecipes> <val>fresh_uox</val> </fuel_inrecipes>
+              <fuel_outcommods> <val>spent_uox</val> </fuel_outcommods>
+              <fuel_outrecipes> <val>spent_uox</val> </fuel_outrecipes>
               <cycle_time>12</cycle_time>
               <refuel_time>1</refuel_time>
               <assem_size>30160</assem_size>
@@ -322,7 +322,7 @@ Add a Second Reactor Input
           <config>
             <Sink>
               <in_commods>
-                <val>spent-uox</val>
+                <val>spent_uox</val>
                 <val>tails</val>
               </in_commods>
             </Sink>
@@ -337,11 +337,11 @@ Add a Second Reactor Input
           <institution>
             <initialfacilitylist>
               <entry>
-                <prototype>1178MWe BRAIDWOOD-1</prototype>
+                <prototype>1178MWe BRAIDWOOD_1</prototype>
                 <number>1</number>
               </entry>
               <entry>
-                <prototype>1000We Lightwater-1</prototype>
+                <prototype>1000We LIGHTWATER_1</prototype>
                 <number>1</number>
               </entry>
             </initialfacilitylist>
@@ -375,7 +375,7 @@ Add a Second Reactor Input
 
 
     <recipe>
-      <name>nat-u</name>
+      <name>nat_u</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -388,7 +388,7 @@ Add a Second Reactor Input
     </recipe>
 
     <recipe>
-      <name>fresh-uox</name>
+      <name>fresh_uox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -401,7 +401,7 @@ Add a Second Reactor Input
     </recipe>
 
     <recipe>
-      <name>spent-uox</name>
+      <name>spent_uox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -471,11 +471,11 @@ Recycle Input
       </archetypes>
 
       <commodity>
-          <name>u-ore</name>
+          <name>u_ore</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-          <name>fresh-uox</name>
+          <name>fresh_uox</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
@@ -483,23 +483,23 @@ Recycle Input
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-          <name>spent-uox</name>
+          <name>spent_uox</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-          <name>used-mox-fuel</name>
+          <name>used_mox_fuel</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-          <name>fresh-mox</name>
+          <name>fresh_mox</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-          <name>separated-fissile</name>
+          <name>separated_fissile</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-          <name>separated-waste</name>
+          <name>separated_waste</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
 
@@ -507,7 +507,7 @@ Recycle Input
           <name>UraniumMine</name>
           <config>
             <Source>
-              <outcommod>u-ore</outcommod>
+              <outcommod>u_ore</outcommod>
             </Source>
           </config>
         </facility>
@@ -516,9 +516,9 @@ Recycle Input
           <name>EnrichmentPlant</name>
           <config>
             <Enrichment>
-              <feed_commod>u-ore</feed_commod>
-              <feed_recipe>nat-u</feed_recipe>
-              <product_commod>fresh-uox</product_commod>
+              <feed_commod>u_ore</feed_commod>
+              <feed_recipe>nat_u</feed_recipe>
+              <product_commod>fresh_uox</product_commod>
               <tails_commod>tails</tails_commod>
               <max_feed_inventory>1000000</max_feed_inventory>
             </Enrichment>
@@ -526,13 +526,13 @@ Recycle Input
         </facility>
 
         <facility>
-          <name>1178MWe BRAIDWOOD-1</name>
+          <name>1178MWe BRAIDWOOD_1</name>
           <config>
             <Reactor>
-              <fuel_incommods> <val>fresh-uox</val> </fuel_incommods>
-              <fuel_inrecipes> <val>fresh-uox</val> </fuel_inrecipes>
-              <fuel_outcommods> <val>spent-uox</val> </fuel_outcommods>
-              <fuel_outrecipes> <val>spent-uox</val> </fuel_outrecipes>
+              <fuel_incommods> <val>fresh_uox</val> </fuel_incommods>
+              <fuel_inrecipes> <val>fresh_uox</val> </fuel_inrecipes>
+              <fuel_outcommods> <val>spent_uox</val> </fuel_outcommods>
+              <fuel_outrecipes> <val>spent_uox</val> </fuel_outrecipes>
               <cycle_time>18</cycle_time>
               <refuel_time>1</refuel_time>
               <assem_size>33000</assem_size>
@@ -544,14 +544,14 @@ Recycle Input
         </facility>
 
         <facility>
-          <name>1000MWe Lightwater-1</name>
+          <name>1000MWe LIGHTWATER_1</name>
           <lifetime>360</lifetime>
           <config>
             <Reactor>
-              <fuel_incommods> <val>fresh-uox</val> </fuel_incommods>
-              <fuel_inrecipes> <val>fresh-uox</val> </fuel_inrecipes>
-              <fuel_outcommods> <val>spent-uox</val> </fuel_outcommods>
-              <fuel_outrecipes> <val>spent-uox</val> </fuel_outrecipes>
+              <fuel_incommods> <val>fresh_uox</val> </fuel_incommods>
+              <fuel_inrecipes> <val>fresh_uox</val> </fuel_inrecipes>
+              <fuel_outcommods> <val>spent_uox</val> </fuel_outcommods>
+              <fuel_outrecipes> <val>spent_uox</val> </fuel_outrecipes>
               <cycle_time>12</cycle_time>
               <refuel_time>1</refuel_time>
               <assem_size>33000</assem_size>
@@ -563,12 +563,12 @@ Recycle Input
         </facility>
 
         <facility>
-          <name>uox-mox-reprocessing</name>
+          <name>uox_mox_reprocessing</name>
           <config>
             <Separations>
                <feed_commods>
-                 <val>used-mox-fuel</val>
-                 <val>spent-uox</val>
+                 <val>used_mox_fuel</val>
+                 <val>spent_uox</val>
                </feed_commods>
                <feed_commod_prefs>
                  <val>1.0</val>
@@ -576,10 +576,10 @@ Recycle Input
                </feed_commod_prefs>
                <feedbuf_size>1000e+3</feedbuf_size>
                <throughput>80e+3</throughput>
-               <leftover_commod>separated-waste</leftover_commod>
+               <leftover_commod>separated_waste</leftover_commod>
                <streams>
                 <item>
-                  <commod>separated-fissile</commod>
+                  <commod>separated_fissile</commod>
                   <info>
                     <buf_size>5e+4</buf_size>
                     <efficiencies>
@@ -598,49 +598,49 @@ Recycle Input
           <config>
             <FuelFab>
               <fill_commods>
-                <val>u-ore</val>
+                <val>u_ore</val>
               </fill_commods>
-              <fill_recipe>nat-u</fill_recipe>
+              <fill_recipe>nat_u</fill_recipe>
               <fill_size>1000e+3</fill_size>
               <fiss_commod_prefs>
                 <val>1</val>
               </fiss_commod_prefs>
               <fiss_commods>
-                <val>separated-fissile</val>
+                <val>separated_fissile</val>
               </fiss_commods>
               <fiss_size>5e+4</fiss_size>
-              <outcommod>fresh-mox</outcommod>
+              <outcommod>fresh_mox</outcommod>
               <spectrum>thermal</spectrum>
               <throughput>2e+3</throughput>
             </FuelFab>
           </config>
-          <name>uox-mox-fuel-fab</name>
+          <name>uox_mox_fuel_fab</name>
         </facility>
 
         <facility>
-          <name>1000MWe ALWR-1</name>
+          <name>1000MWe ALWR_1</name>
           <lifetime>360</lifetime>
           <config>
             <Reactor>
               <fuel_incommods>
-                <val>fresh-uox</val>
-                <val>fresh-mox</val>
+                <val>fresh_uox</val>
+                <val>fresh_mox</val>
               </fuel_incommods>
               <fuel_inrecipes>
-                <val>fresh-uox</val>
-                <val>fresh-uox</val>
+                <val>fresh_uox</val>
+                <val>fresh_uox</val>
               </fuel_inrecipes>
               <fuel_prefs>
                 <val>1.0</val>
                 <val>2.0</val>
               </fuel_prefs>
               <fuel_outcommods>
-                <val>spent-uox</val>
-                <val>used-mox-fuel</val>
+                <val>spent_uox</val>
+                <val>used_mox_fuel</val>
               </fuel_outcommods>
               <fuel_outrecipes>
-                <val>spent-uox</val>
-                <val>used-mox</val>
+                <val>spent_uox</val>
+                <val>used_mox</val>
               </fuel_outrecipes>
               <cycle_time>18</cycle_time>
               <refuel_time>1</refuel_time>
@@ -658,9 +658,9 @@ Recycle Input
           <config>
             <Sink>
               <in_commods>
-                <val>spent-uox</val>
+                <val>spent_uox</val>
                 <val>tails</val>
-                <val>separated-waste</val>
+                <val>separated_waste</val>
               </in_commods>
             </Sink>
           </config>
@@ -675,15 +675,15 @@ Recycle Input
           <institution>
             <initialfacilitylist>
               <entry>
-                <prototype>1178MWe BRAIDWOOD-1</prototype>
+                <prototype>1178MWe BRAIDWOOD_1</prototype>
                 <number>1</number>
               </entry>
               <entry>
-                <prototype>1000MWe Lightwater-1</prototype>
+                <prototype>1000MWe LIGHTWATER_1</prototype>
                 <number>1</number>
               </entry>
               <entry>
-                <prototype>1000MWe ALWR-1</prototype>
+                <prototype>1000MWe ALWR_1</prototype>
                 <number>1</number>
               </entry>
             </initialfacilitylist>
@@ -708,11 +708,11 @@ Recycle Input
                 <number>1</number>
               </entry>
               <entry>
-                <prototype>uox-mox-reprocessing</prototype>
+                <prototype>uox_mox_reprocessing</prototype>
                 <number>1</number>
               </entry>
               <entry>
-                <prototype>uox-mox-fuel-fab</prototype>
+                <prototype>uox_mox_fuel_fab</prototype>
                 <number>1</number>
               </entry>
             </initialfacilitylist>
@@ -725,7 +725,7 @@ Recycle Input
 
 
     <recipe>
-      <name>nat-u</name>
+      <name>nat_u</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -738,7 +738,7 @@ Recycle Input
     </recipe>
 
     <recipe>
-      <name>fresh-uox</name>
+      <name>fresh_uox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -750,7 +750,7 @@ Recycle Input
       </nuclide>
     </recipe>
     <recipe>
-      <name>used-mox</name>
+      <name>used_mox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -774,7 +774,7 @@ Recycle Input
       </nuclide>
     </recipe>
     <recipe>
-      <name>spent-uox</name>
+      <name>spent_uox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -850,11 +850,11 @@ DeployInst Input
       </archetypes>
 
       <commodity>
-          <name>u-ore</name>
+          <name>u_ore</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-          <name>fresh-uox</name>
+          <name>fresh_uox</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
@@ -862,23 +862,23 @@ DeployInst Input
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-          <name>spent-uox</name>
+          <name>spent_uox</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-          <name>used-mox-fuel</name>
+          <name>used_mox_fuel</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-          <name>fresh-mox</name>
+          <name>fresh_mox</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-          <name>separated-fissile</name>
+          <name>separated_fissile</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-          <name>separated-waste</name>
+          <name>separated_waste</name>
           <solution_priority>1.0</solution_priority>
       </commodity>
 
@@ -886,7 +886,7 @@ DeployInst Input
           <name>UraniumMine</name>
           <config>
             <Source>
-              <outcommod>u-ore</outcommod>
+              <outcommod>u_ore</outcommod>
             </Source>
           </config>
         </facility>
@@ -895,9 +895,9 @@ DeployInst Input
           <name>EnrichmentPlant</name>
           <config>
             <Enrichment>
-              <feed_commod>u-ore</feed_commod>
-              <feed_recipe>nat-u</feed_recipe>
-              <product_commod>fresh-uox</product_commod>
+              <feed_commod>u_ore</feed_commod>
+              <feed_recipe>nat_u</feed_recipe>
+              <product_commod>fresh_uox</product_commod>
               <tails_commod>tails</tails_commod>
               <max_feed_inventory>1000000</max_feed_inventory>
             </Enrichment>
@@ -905,13 +905,13 @@ DeployInst Input
         </facility>
 
         <facility>
-          <name>1178MWe BRAIDWOOD-1</name>
+          <name>1178MWe BRAIDWOOD_1</name>
           <config>
             <Reactor>
-              <fuel_incommods> <val>fresh-uox</val> </fuel_incommods>
-              <fuel_inrecipes> <val>fresh-uox</val> </fuel_inrecipes>
-              <fuel_outcommods> <val>spent-uox</val> </fuel_outcommods>
-              <fuel_outrecipes> <val>spent-uox</val> </fuel_outrecipes>
+              <fuel_incommods> <val>fresh_uox</val> </fuel_incommods>
+              <fuel_inrecipes> <val>fresh_uox</val> </fuel_inrecipes>
+              <fuel_outcommods> <val>spent_uox</val> </fuel_outcommods>
+              <fuel_outrecipes> <val>spent_uox</val> </fuel_outrecipes>
               <cycle_time>18</cycle_time>
               <refuel_time>1</refuel_time>
               <assem_size>33000</assem_size>
@@ -923,14 +923,14 @@ DeployInst Input
         </facility>
 
         <facility>
-          <name>1000MWe Lightwater-1</name>
+          <name>1000MWe LIGHTWATER_1</name>
           <lifetime>360</lifetime>
           <config>
             <Reactor>
-              <fuel_incommods> <val>fresh-uox</val> </fuel_incommods>
-              <fuel_inrecipes> <val>fresh-uox</val> </fuel_inrecipes>
-              <fuel_outcommods> <val>spent-uox</val> </fuel_outcommods>
-              <fuel_outrecipes> <val>spent-uox</val> </fuel_outrecipes>
+              <fuel_incommods> <val>fresh_uox</val> </fuel_incommods>
+              <fuel_inrecipes> <val>fresh_uox</val> </fuel_inrecipes>
+              <fuel_outcommods> <val>spent_uox</val> </fuel_outcommods>
+              <fuel_outrecipes> <val>spent_uox</val> </fuel_outrecipes>
               <cycle_time>12</cycle_time>
               <refuel_time>1</refuel_time>
               <assem_size>33000</assem_size>
@@ -942,12 +942,12 @@ DeployInst Input
         </facility>
 
         <facility>
-          <name>uox-mox-reprocessing</name>
+          <name>uox_mox_reprocessing</name>
           <config>
             <Separations>
                <feed_commods>
-                 <val>used-mox-fuel</val>
-                 <val>spent-uox</val>
+                 <val>used_mox_fuel</val>
+                 <val>spent_uox</val>
                </feed_commods>
                <feed_commod_prefs>
                  <val>1.0</val>
@@ -955,10 +955,10 @@ DeployInst Input
                </feed_commod_prefs>
                <feedbuf_size>1000e+3</feedbuf_size>
                <throughput>80e+3</throughput>
-               <leftover_commod>separated-waste</leftover_commod>
+               <leftover_commod>separated_waste</leftover_commod>
                <streams>
                 <item>
-                  <commod>separated-fissile</commod>
+                  <commod>separated_fissile</commod>
                   <info>
                     <buf_size>5e+4</buf_size>
                     <efficiencies>
@@ -977,49 +977,49 @@ DeployInst Input
           <config>
             <FuelFab>
               <fill_commods>
-                <val>u-ore</val>
+                <val>u_ore</val>
               </fill_commods>
-              <fill_recipe>nat-u</fill_recipe>
+              <fill_recipe>nat_u</fill_recipe>
               <fill_size>1000e+3</fill_size>
               <fiss_commod_prefs>
                 <val>1</val>
               </fiss_commod_prefs>
               <fiss_commods>
-                <val>separated-fissile</val>
+                <val>separated_fissile</val>
               </fiss_commods>
               <fiss_size>5e+4</fiss_size>
-              <outcommod>fresh-mox</outcommod>
+              <outcommod>fresh_mox</outcommod>
               <spectrum>thermal</spectrum>
               <throughput>2e+3</throughput>
             </FuelFab>
           </config>
-          <name>uox-mox-fuel-fab</name>
+          <name>uox_mox_fuel_fab</name>
         </facility>
 
         <facility>
-          <name>1000MWe ALWR-1</name>
+          <name>1000MWe ALWR_1</name>
           <lifetime>360</lifetime>
           <config>
             <Reactor>
               <fuel_incommods>
-                <val>fresh-uox</val>
-                <val>fresh-mox</val>
+                <val>fresh_uox</val>
+                <val>fresh_mox</val>
               </fuel_incommods>
               <fuel_inrecipes>
-                <val>fresh-uox</val>
-                <val>fresh-uox</val>
+                <val>fresh_uox</val>
+                <val>fresh_uox</val>
               </fuel_inrecipes>
               <fuel_prefs>
                 <val>1.0</val>
                 <val>2.0</val>
               </fuel_prefs>
               <fuel_outcommods>
-                <val>spent-uox</val>
-                <val>used-mox-fuel</val>
+                <val>spent_uox</val>
+                <val>used_mox_fuel</val>
               </fuel_outcommods>
               <fuel_outrecipes>
-                <val>spent-uox</val>
-                <val>used-mox</val>
+                <val>spent_uox</val>
+                <val>used_mox</val>
               </fuel_outrecipes>
               <cycle_time>18</cycle_time>
               <refuel_time>1</refuel_time>
@@ -1037,9 +1037,9 @@ DeployInst Input
           <config>
             <Sink>
               <in_commods>
-                <val>spent-uox</val>
+                <val>spent_uox</val>
                 <val>tails</val>
-                <val>separated-waste</val>
+                <val>separated_waste</val>
               </in_commods>
             </Sink>
           </config>
@@ -1054,15 +1054,15 @@ DeployInst Input
           <institution>
             <initialfacilitylist>
               <entry>
-                <prototype>1178MWe BRAIDWOOD-1</prototype>
+                <prototype>1178MWe BRAIDWOOD_1</prototype>
                 <number>1</number>
               </entry>
               <entry>
-                <prototype>1000MWe Lightwater-1</prototype>
+                <prototype>1000MWe LIGHTWATER_1</prototype>
                 <number>1</number>
               </entry>
               <entry>
-                <prototype>1000MWe ALWR-1</prototype>
+                <prototype>1000MWe ALWR_1</prototype>
                 <number>1</number>
               </entry>
             </initialfacilitylist>
@@ -1087,11 +1087,11 @@ DeployInst Input
                 <number>1</number>
               </entry>
               <entry>
-                <prototype>uox-mox-reprocessing</prototype>
+                <prototype>uox_mox_reprocessing</prototype>
                 <number>1</number>
               </entry>
               <entry>
-                <prototype>uox-mox-fuel-fab</prototype>
+                <prototype>uox_mox_fuel_fab</prototype>
                 <number>1</number>
               </entry>
             </initialfacilitylist>
@@ -1107,8 +1107,8 @@ DeployInst Input
 	              <prototypes>
 	                <val>UraniumMine</val>
             	    <val>FuelFab</val>
-	                <val>1178MWe BRAIDWOOD-1</val>
-	                <val>1000MWe Lightwater-1</val>
+	                <val>1178MWe BRAIDWOOD_1</val>
+	                <val>1000MWe LIGHTWATER_1</val>
 	              </prototypes>
 	              <build_times>
 	                <val>1</val>
@@ -1129,7 +1129,7 @@ DeployInst Input
 
 
     <recipe>
-      <name>nat-u</name>
+      <name>nat_u</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -1142,7 +1142,7 @@ DeployInst Input
     </recipe>
 
     <recipe>
-      <name>fresh-uox</name>
+      <name>fresh_uox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -1154,7 +1154,7 @@ DeployInst Input
       </nuclide>
     </recipe>
     <recipe>
-      <name>used-mox</name>
+      <name>used_mox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -1178,7 +1178,7 @@ DeployInst Input
       </nuclide>
     </recipe>
     <recipe>
-      <name>spent-uox</name>
+      <name>spent_uox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>

--- a/source/user/tutorial/full_input_1.rst
+++ b/source/user/tutorial/full_input_1.rst
@@ -39,11 +39,11 @@
 
 
     <commodity>
-        <name>u-ore</name>
+        <name>u_ore</name>
         <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-        <name>fresh-uox</name>
+        <name>fresh_uox</name>
         <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
@@ -51,12 +51,12 @@
         <solution_priority>1.0</solution_priority>
       </commodity>
       <commodity>
-        <name>spent-uox</name>
+        <name>spent_uox</name>
         <solution_priority>1.0</solution_priority>
     </commodity>
 
     <recipe>
-      <name>nat-u</name>
+      <name>nat_u</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -69,7 +69,7 @@
     </recipe>
 
     <recipe>
-      <name>fresh-uox</name>
+      <name>fresh_uox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -82,7 +82,7 @@
     </recipe>
 
     <recipe>
-      <name>spent-uox</name>
+      <name>spent_uox</name>
       <basis>mass</basis>
       <nuclide>
         <id>92235</id>
@@ -107,7 +107,7 @@
     <name>UraniumMine</name>
     <config>
       <Source>
-        <outcommod>u-ore</outcommod>
+        <outcommod>u_ore</outcommod>
       </Source>
     </config>
   </facility>
@@ -116,9 +116,9 @@
     <name>EnrichmentPlant</name>
     <config>
       <Enrichment>
-        <feed_commod>u-ore</feed_commod>
-        <feed_recipe>nat-u</feed_recipe>
-        <product_commod>fresh-uox</product_commod>
+        <feed_commod>u_ore</feed_commod>
+        <feed_recipe>nat_u</feed_recipe>
+        <product_commod>fresh_uox</product_commod>
         <tails_commod>tails</tails_commod>
         <max_feed_inventory>1000000</max_feed_inventory>
       </Enrichment>
@@ -126,13 +126,13 @@
   </facility>
   
   <facility>
-    <name>1178MWe BRAIDWOOD-1</name>
+    <name>1178MWe BRAIDWOOD_1</name>
     <config>
       <Reactor>
-        <fuel_incommods> <val>fresh-uox</val> </fuel_incommods>
-        <fuel_inrecipes> <val>fresh-uox</val> </fuel_inrecipes>
-        <fuel_outcommods> <val>spent-uox</val> </fuel_outcommods>
-        <fuel_outrecipes> <val>spent-uox</val> </fuel_outrecipes>
+        <fuel_incommods> <val>fresh_uox</val> </fuel_incommods>
+        <fuel_inrecipes> <val>fresh_uox</val> </fuel_inrecipes>
+        <fuel_outcommods> <val>spent_uox</val> </fuel_outcommods>
+        <fuel_outrecipes> <val>spent_uox</val> </fuel_outrecipes>
         <cycle_time>18</cycle_time>
         <refuel_time>1</refuel_time>
         <assem_size>33000</assem_size>
@@ -148,7 +148,7 @@
     <config>
       <Sink>
         <in_commods>
-          <val>spent-uox</val>
+          <val>spent_uox</val>
           <val>tails</val>
         </in_commods>
       </Sink>
@@ -164,7 +164,7 @@
     <institution>
       <initialfacilitylist>
         <entry>
-          <prototype>1178MWe BRAIDWOOD-1</prototype>
+          <prototype>1178MWe BRAIDWOOD_1</prototype>
           <number>1</number>
         </entry>
         </initialfacilitylist>


### PR DESCRIPTION
Apparently in Cyclus input files you cannot have "-" in the names of things. However, in the tutorials on the website we were telling people to make variables like "u-ore" and "fresh-uox", so I went in and changed all of those to "u_ore" and "fresh_uox", etc. I also added a note above one of the images which showed an incorrect variable name that you aren't allowed to have "-" in your names so it was more clear/consistent.

This PR Closes #394 