### PR TITLE
Added command to Install for adding conda forge as a channel

### DIFF
--- a/source/atemplates/sidebar.html
+++ b/source/atemplates/sidebar.html
@@ -23,7 +23,7 @@
     Current version: <b>1.6.0</b>
     <br><br>
     Install:
-    <div class="highlight-bash" style="width:97.5%"><div class="highlight"><pre><span class="nv">$ </span>conda config --add channels conda-forge<br><span class="nv">$ </span>conda install cyclus cycamore</pre></div></div>
+    <div class="highlight-bash" style="width:97.5%"><div class="highlight"><pre><span class="nv">$ </span>conda install -c conda-forge cyclus cycamore</pre></div></div>  
     Get the Source:
     <ul><li><ul>
           <li><a href="https://github.com/cyclus/cyclus">Cyclus</a></li>

--- a/source/atemplates/sidebar.html
+++ b/source/atemplates/sidebar.html
@@ -23,7 +23,7 @@
     Current version: <b>1.6.0</b>
     <br><br>
     Install:
-    <div class="highlight-bash" style="width:97.5%"><div class="highlight"><pre><span class="nv">$ </span>conda install cyclus cycamore</pre></div></div>
+    <div class="highlight-bash" style="width:97.5%"><div class="highlight"><pre><span class="nv">$ </span>conda config --add channels conda-forge<br><span class="nv">$ </span>conda install cyclus cycamore</pre></div></div>
     Get the Source:
     <ul><li><ul>
           <li><a href="https://github.com/cyclus/cyclus">Cyclus</a></li>


### PR DESCRIPTION
Previously the instructions just said to `conda install cyclus cycamore`, but made no mention of that only being available on the conda forge channel. For experienced users, this may be obvious to troubleshoot, but for people newer to conda (undergrads, new grad students, people who don't do a lot of coding, etc) this provides a frustrating bottleneck. This PR updates the commands under the `Install:` header of the sidebar to include `conda config --add channels conda-forge` which will add conda forge as a channel to the users conda env.

Closes #404 