### PR TITLE
Readme build instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,28 @@ Best practice workflow for contributing to site changes
    ``make docker-gh-preview``
 
    to build the website inside a docker container with all the correct
-   dependencies and configuration taken care of automagically.
+   dependencies and configuration taken care of automagically. Once this
+   is done, navigate into the gh-build directory and serve the website.
+
+   ``cd gh-build``
+   ``python3 -m http:server <port number>``
+
+   the most common port number for things like this is 8000, or 8080,
+   and as such choosing one of these is recommended:
+
+   ``python3 -m http:server 8000``
+
+   If you are building the website on a computer which you are 
+   connected to remotely, it will then be necessary to create a tunnel
+   between your local and remote machines. This can be done with:
+
+   ``ssh -L <port number>:localhost:<port number> username@remote``
+
+   So if using port 8000 as in the example above, and connecting to a
+   remote machine which you had listed in your config file as "remote-machine"
+   the command would look something like this:
+
+   ``ssh -L 8000:localhost:8000 username@remote-machine``
 
 6. Repeat steps 4-5 until satisfied.
 

--- a/README.rst
+++ b/README.rst
@@ -85,8 +85,12 @@ Best practice workflow for contributing to site changes
    dependencies and configuration taken care of automagically. Once this
    is done, navigate into the gh-build directory and serve the website.
 
-   ``cd gh-build``
-   ``python3 -m http:server <port number>``
+
+   ::
+      
+      cd gh-build
+      python3 -m http:server <port number>
+   
 
    the most common port number for things like this is 8000, or 8080,
    and as such choosing one of these is recommended:

--- a/README.rst
+++ b/README.rst
@@ -89,13 +89,13 @@ Best practice workflow for contributing to site changes
    ::
       
       cd gh-build
-      python3 -m http:server <port number>
+      python3 -m http.server <port number>
    
 
    the most common port number for things like this is 8000, or 8080,
    and as such choosing one of these is recommended:
 
-   ``python3 -m http:server 8000``
+   ``python3 -m http.server 8000``
 
    If you are building the website on a computer which you are 
    connected to remotely, it will then be necessary to create a tunnel

--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,15 @@ Best practice workflow for contributing to site changes
 
    ``ssh -L 8000:localhost:8000 username@remote-machine``
 
+   Finally, connect to the website on your computer by opening a browser
+   and going to:
+
+   ``http://localhost:<port number>``
+
+   which in the example above would look like:
+
+   ``http://loaclhost:8000``
+
 6. Repeat steps 4-5 until satisfied.
 
 7. Once satisfied with the source RST files, push your branch to your fork of


### PR DESCRIPTION
Previous versions of the README left users (me when I was trying to do this for the first time) high and dry after telling them to run `make docker-gh-preview`. It was not at all clear that to actually view the changes made to the website it needed to be served and visited at localhost. This version of the README gives users (especially new ones) more detailed instructions on exactly what they need to do after they make changes to the website so that they can check their work.

Closes #397 