### PR TITLE
Wipe cycstub repo

### DIFF
--- a/source/arche/cli.rst
+++ b/source/arche/cli.rst
@@ -13,7 +13,7 @@ single-string form ``spec`` (e.g. ``:cycamore:Source``) which is discussed
 To view the auto-generated XML schema used for validating archetype
 configuration parameters in input files:
 
-  .. code-block:: bash
+  .. code-block:: console
 
       $ cyclus --agent-schema :agents:Source
       <interleave>
@@ -33,7 +33,7 @@ configuration parameters in input files:
 To view a JSON structured output of all the data generated and collected from
 ``#pragma cyclus`` annotations for a particular archetype:
 
-  .. code-block:: bash
+  .. code-block:: console
 
       $ cyclus --agent-annotations :cycamore:Source
       {
@@ -52,7 +52,7 @@ To view a JSON structured output of all the data generated and collected from
 
 And to list all archetypes inside a particular library:
 
-  .. code-block:: bash
+  .. code-block:: console
 
       $ cyclus --agent-listing :cycamore
       :cycamore:DeployInst
@@ -71,7 +71,7 @@ Archetype Versioning
 The ``cyclus::Agent`` class exposes a ``version()`` member function which can be
 queried with the |Cyclus| CLI. For example,
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cyclus --agent-version :agents:Source
     1.3.1-7-g9a2c9c9
@@ -94,7 +94,7 @@ your own version tag information for some archetype like
 
 and then access the version with
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cyclus --agent-version my/path:my_library:MyArchetype
     My Version

--- a/source/arche/cmake.rst
+++ b/source/arche/cmake.rst
@@ -3,7 +3,7 @@
 Building Modules with CMake
 ===========================
 
-If you haven't follow the initial example in :ref:`hello_world_cpp`, you should use
+If you haven't followed the initial example in :ref:`hello_world_cpp`, you should use
 ``cycstub`` to generate a directory with the "stubs" to build a new archetype.
 (see :ref:`hello_world_cpp` for further instructions).
 

--- a/source/arche/cmake.rst
+++ b/source/arche/cmake.rst
@@ -3,13 +3,11 @@
 Building Modules with CMake
 ===========================
 
-If you haven't follow the initial example in :ref:`hello_world_cpp`, you should get
-the `Cycstub repo <https://github.com/cyclus/cycstub>`_ by either `cloning the
-repository <https://github.com/cyclus/cycstub.git>`_ or by `downloading the zip
-file <https://github.com/cyclus/cycstub/archive/develop.zip>`_ (see
-:ref:`hello_world_cpp` for further instructions).
+If you haven't follow the initial example in :ref:`hello_world_cpp`, you should use
+``cycstub`` to generate a directory with the "stubs" to build a new archetype.
+(see :ref:`hello_world_cpp` for further instructions).
 
-The Cycstub repo provides a number of critical tools for building your own
+The ``cycstub`` utility provides a number of critical tools for building your own
 module:
 
 * ``install.py``: a basic installation script

--- a/source/arche/cmake.rst
+++ b/source/arche/cmake.rst
@@ -95,12 +95,44 @@ listing:
 
 Examples
 --------
-    
+
+Module Installation
++++++++++++++++++++
+
+The "Hello World" example only allows you to add multiple archetypes to the same
+module/library, using the `USE_CYCLUS` and `INSTALL_CYCLUS_MODULE` macros.  If
+you call `cycstub` multiple times in the same folder, it requires you to specify
+the same path and library name for each new archetype.  This approach reduces
+the number of libraries and executables that are added to a system, perhaps
+unnecessarily.
+
+The resulting `src/CMakeLists.txt` file will includes lines like this:
+
+.. literalinclude:: module-cmake
+
+This will generate:
+
+* a single shared object library in ``$CYCLUS_INSTALL_PREFIX/lib/cyclus/tutorial``
+  named ``libTutorialLibrary.so`` (\*nix) or ``libTutorialLibrary.dylib`` (mac)
+
+* a single unit test executable in ``$CYCLUS_INSTALL_PREFIX/bin`` named
+  ``TutorialLibrary_unit_tests``
+
+where both incorporate the ``TutorialFacility``, ``TutorialInstitution``, and
+``TutorialRegion`` :term:`archetypes <archetype>`.
+
+
 Standalone Installation
 +++++++++++++++++++++++
 
-Through the :ref:`hello_world` example, three standalone modules are installed
-using a ``src/CMakeLists.txt`` file that looks something like
+There may be cases where one prefers to have separate libraries and executables
+for each archetype.  This is not currently supported by `cycstub` in a direct
+way. However, you can modify the above module approach by editing
+``src/CMakeLists.txt`` and replacing:
+
+.. literalinclude:: module-cmake
+
+with 
 
 .. literalinclude:: standalone-cmake
 
@@ -121,29 +153,5 @@ and three unit test executables in ``$CYCLUS_INSTALL_PREFIX/bin``:
 
 * ``TutorialRegion_unit_tests``
 
-Module Installation
-+++++++++++++++++++
-
-A valid criticism of the hello world standalone approach is that a lot of
-libraries and executables are generated for three modules that are grouped
-together. We can do better!
-
-What if we wanted to install one module named ``helloworld``? Specifically, we
-would want:
-
-* a single shared object library in ``$CYCLUS_INSTALL_PREFIX/lib/cyclus/tutorial``
-  named ``libhelloworld.so`` (\*nix) or ``libhelloworld.dylib`` (mac)
-
-* a single unit test executable in ``$CYCLUS_INSTALL_PREFIX/bin`` named
-  ``helloworld_unit_tests``
-
-where both incorporate the ``TutorialFacility``, ``TutorialInstitution``, and
-``TutorialRegion`` :term:`archetypes <archetype>`.
-
-Such behavior is pretty simple to achieve. We first must call ``UseCyclus`` on
-each of our source file roots to inform the build system of their presence and
-follow up with a call to ``INSTALL_CYCLUS_MODULE``:
-
-.. literalinclude:: module-cmake
     
 

--- a/source/arche/cmake.rst
+++ b/source/arche/cmake.rst
@@ -67,7 +67,7 @@ The ``UseCyclus.cmake`` macro suite uses the following terms:
   ``$CYCLUS_INSTALL_PREFIX/lib/cyclus/my_module_dir/``. The value of
   ``$CYCLUS_INSTALL_PREFIX`` can be queried by
 
-  .. code-block:: bash
+  .. code-block:: console
 
       $ cyclus --install-path
 

--- a/source/arche/errors.rst
+++ b/source/arche/errors.rst
@@ -132,7 +132,7 @@ suppress all warnings and a very large number will print them all.  For
 example, if the user wished to print the first 42 warnings of each kind they
 would call |cyclus| as follows:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cyclus --warn-limit 42 ...
 
@@ -142,7 +142,7 @@ and throws the error.  This is useful for ensuring that only stable code is
 executed or to help uncover what is causing a warning to be thrown.  It takes
 no arguments:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cyclus --warn-as-error ...
 

--- a/source/arche/hello_world_cpp.rst
+++ b/source/arche/hello_world_cpp.rst
@@ -62,7 +62,7 @@ The install script puts the project into your cyclus userspace,
 ------------
 
 Let's run |cyclus| with the TutorialFacility! In the input directory there is
-an :file:`example.xml`. Running |cyclus| on this file with the command
+an :file:`example_tutorial_facility.xml`. Running |cyclus| on this file with the command
 ``cyclus example_tutorial_facility.xml`` should produce the following output.
 
 .. code-block:: bash

--- a/source/arche/hello_world_cpp.rst
+++ b/source/arche/hello_world_cpp.rst
@@ -4,7 +4,7 @@ Hello, Cyclus! [C++]
 ====================
 This pages walks you through a very simple hello world example using
 |cyclus| agents.  First make sure that you have the dependencies installed,
-namely |Cyclus|, CMake, and a recent version of Python (3.3+).
+namely |Cyclus|, CMake, and a recent version of Python (3.11+).
 
 First, you need to use ``cycstub`` to generate a skeleton code base
 that you can use to quick-start new |cyclus| module development projects.

--- a/source/arche/hello_world_cpp.rst
+++ b/source/arche/hello_world_cpp.rst
@@ -12,7 +12,7 @@ that you can use to quick-start new |cyclus| module development projects.
 available whereever ``cyclus`` is available.
 
 To use ``cycstub`` to generate the skeleton for a new Facility archetype named ``TutorialFacility`` in
-a module named ``TutorialFacility`` you can issue the following command:
+a module named ``tutorialfacility`` you can issue the following command:
 
 .. code-block:: bash
 

--- a/source/arche/hello_world_cpp.rst
+++ b/source/arche/hello_world_cpp.rst
@@ -9,7 +9,7 @@ namely |Cyclus|, CMake, and a recent version of Python (3.3+).
 First, you need to use ``cycstub`` to generate a skeleton code base
 that you can use to quick-start new |cyclus| module development projects.
 ``cycstub`` is installed with the main ``cyclus`` kernel and should be
-available whereever ``cyclus`` is available.
+available wherever ``cyclus`` is available.
 
 To use ``cycstub`` to generate the skeleton for a new Facility archetype named ``TutorialFacility`` in
 a module named ``tutorialfacility`` you can issue the following command:
@@ -29,7 +29,7 @@ will not do anything.
 Let's now change the behavior of the TutorialFacility's ``Tick()`` &
 ``Tock()`` member functions to print "Hello" and "World" respectively.  To do
 this, please open up the :file:`src/tutorial_facility.cc` file in your
-favorite text editor (vim, emacs, gedit, `VS Code <https://code.visualstudio.com/>`_).
+favorite text editor (e.g., vim, emacs, gedit, `VS Code <https://code.visualstudio.com/>`_).
 Change the original functions to look like:
 
 **Original Tick() and Tock() in src/tutorial_facility.cc:**

--- a/source/arche/hello_world_cpp.rst
+++ b/source/arche/hello_world_cpp.rst
@@ -4,48 +4,32 @@ Hello, Cyclus! [C++]
 ====================
 This pages walks you through a very simple hello world example using
 |cyclus| agents.  First make sure that you have the dependencies installed,
-namely |Cyclus|, CMake, and a recent version of Python (2.7 or 3.3+).
+namely |Cyclus|, CMake, and a recent version of Python (3.3+).
 
-First, you need to get the ``cycstub`` code.  Cycstub is a skeleton code base
+First, you need to use ``cycstub`` to generate a skeleton code base
 that you can use to quick-start new |cyclus| module development projects.
-You can grab cycstub either by using git to
-`clone the repository <https://github.com/cyclus/cycstub.git>`_ or by
-`downloading the zip file <https://github.com/cyclus/cycstub/archive/develop.zip>`_.
-Let's put this code in a ``tutorial`` directory and go into it.
+``cycstub`` is installed with the main ``cyclus`` kernel and should be
+available whereever ``cyclus`` is available.
 
-**Getting cycstub via git:**
-
-.. code-block:: bash
-
-    $ git clone https://github.com/cyclus/cycstub.git tutorial
-    $ cd tutorial
-
-**Getting cycstub via zip:**
+To use ``cycstub`` to generate the skeleton for a new Facility archetype named ``TutorialFacility`` in
+a module named ``TutorialFacility`` you can issue the following command:
 
 .. code-block:: bash
 
-    $ curl -L https://api.github.com/repos/cyclus/cycstub/zipball > tutorial.zip
-    $ unzip tutorial.zip
-    $ mv cyclus-cycstub-* tutorial
-    $ cd tutorial
+    tutorial $ mkdir TutorialFacility
+    tutorial $ cd TutorialFacility
+    TutorialFacility $ cycstub --type facility :tutorialfacility:TutorialFacility
 
-------------
-
-Since cycstub is a template project everything is named ``stub``. We need to
-change this to reflect the name we want our new project to be called -
-``tutorial`` here.  Cycstub comes with a renaming tool to do just this! From
-the command line, run Python in the following way:
-
-.. code-block:: bash
-
-    tutorial $ python rename.py tutorial
+This will populate the ``TutorialFacility`` directory with a number of files and subdirectories
+that should already be complete for building a new archetype.  Without any changes, this archetype
+will not do anything.
 
 ------------
 
 Let's now change the behavior of the TutorialFacility's ``Tick()`` &
 ``Tock()`` member functions to print "Hello" and "World" respectively.  To do
 this, please open up the :file:`src/tutorial_facility.cc` file in your
-favorite text editor (vim, emacs, gedit, `notepad++ <http://exofrills.org>`_).
+favorite text editor (vim, emacs, gedit, `VS Code <https://code.visualstudio.com/>`_).
 Change the original functions to look like:
 
 **Original Tick() and Tock() in src/tutorial_facility.cc:**
@@ -73,17 +57,17 @@ The install script puts the project into your cyclus userspace,
 
 .. code-block:: bash
 
-    tutorial $ python install.py
+    tutorial $ python3 install.py
 
 ------------
 
 Let's run |cyclus| with the TutorialFacility! In the input directory there is
 an :file:`example.xml`. Running |cyclus| on this file with the command
-``cyclus input/example.xml`` should produce the following output.
+``cyclus example_tutorial_facility.xml`` should produce the following output.
 
 .. code-block:: bash
 
-    tutorial $ cyclus input/example.xml
+    tutorial $ cyclus example_tutorial_facility.xml
                   :
               .CL:CC CC             _Q     _Q  _Q_Q    _Q    _Q              _Q
             CC;CCCCCCCC:C;         /_\)   /_\)/_/\\)  /_\)  /_\)            /_\)

--- a/source/arche/hello_world_cpp.rst
+++ b/source/arche/hello_world_cpp.rst
@@ -16,7 +16,7 @@ a module named ``TutorialLibrary`` you can issue the following command:
 
 .. code-block:: console
 
-    tutorial $ cycstub --type facility tutorial:TutorialLibrary:TutorialFacility
+    $ cycstub --type facility tutorial:TutorialLibrary:TutorialFacility
 
 This will populate the ``tutorial`` directory with a number of files and subdirectories
 that should already be complete for building a new archetype.  Without any changes, this archetype
@@ -26,8 +26,8 @@ You can add additional agents to this module by calling `cycstub` multiple times
 
 .. code-block:: console
 
-    tutorial $ cycstub --type inst tutorial:TutorialLibrary:TutorialInstitution
-    tutorial $ cycstub --type region tutorial:TutorialLibrary:TutorialRegion
+    $ cycstub --type inst tutorial:TutorialLibrary:TutorialInstitution
+    $ cycstub --type region tutorial:TutorialLibrary:TutorialRegion
 
 ------------
 
@@ -62,7 +62,7 @@ The install script puts the project into your cyclus userspace,
 
 .. code-block:: console
 
-    tutorial $ python3 install.py
+    $ python3 install.py
 
 ------------
 
@@ -72,7 +72,7 @@ an :file:`example_tutorial_facility.xml`. Running |cyclus| on this file with the
 
 .. code-block:: console
 
-    tutorial $ cyclus example_tutorial_facility.xml
+    $ cyclus example_tutorial_facility.xml
                   :
               .CL:CC CC             _Q     _Q  _Q_Q    _Q    _Q              _Q
             CC;CCCCCCCC:C;         /_\)   /_\)/_/\\)  /_\)  /_\)            /_\)

--- a/source/arche/hello_world_cpp.rst
+++ b/source/arche/hello_world_cpp.rst
@@ -14,7 +14,7 @@ available wherever ``cyclus`` is available.
 To use ``cycstub`` to generate the skeleton for a new Facility archetype named ``TutorialFacility`` in
 a module named ``TutorialLibrary`` you can issue the following command:
 
-.. code-block:: bash
+.. code-block:: console
 
     tutorial $ cycstub --type facility tutorial:TutorialLibrary:TutorialFacility
 
@@ -24,7 +24,7 @@ will not do anything, but will be a valid archetype for use in a simulation.
 
 You can add additional agents to this module by calling `cycstub` multiple times:
 
-.. code-block:: bash
+.. code-block:: console
 
     tutorial $ cycstub --type inst tutorial:TutorialLibrary:TutorialInstitution
     tutorial $ cycstub --type region tutorial:TutorialLibrary:TutorialRegion
@@ -60,7 +60,7 @@ install the ``tutorial`` project.  This done with the install.py script.
 The install script puts the project into your cyclus userspace,
 ``${HOME}/.local/lib/cyclus``.
 
-.. code-block:: bash
+.. code-block:: console
 
     tutorial $ python3 install.py
 
@@ -70,7 +70,7 @@ Let's run |cyclus| with the TutorialFacility! In the input directory there is
 an :file:`example_tutorial_facility.xml`. Running |cyclus| on this file with the command
 ``cyclus example_tutorial_facility.xml`` should produce the following output.
 
-.. code-block:: bash
+.. code-block:: console
 
     tutorial $ cyclus example_tutorial_facility.xml
                   :

--- a/source/arche/hello_world_cpp.rst
+++ b/source/arche/hello_world_cpp.rst
@@ -16,7 +16,7 @@ a module named ``TutorialLibrary`` you can issue the following command:
 
 .. code-block:: bash
 
-    tutorial $ cycstub --type facility :TutorialLibrary:TutorialFacility
+    tutorial $ cycstub --type facility tutorial:TutorialLibrary:TutorialFacility
 
 This will populate the ``tutorial`` directory with a number of files and subdirectories
 that should already be complete for building a new archetype.  Without any changes, this archetype
@@ -26,8 +26,8 @@ You can add additional agents to this module by calling `cycstub` multiple times
 
 .. code-block:: bash
 
-    tutorial $ cycstub --type inst :TutorialLibrary:TutorialInstitution
-    tutorial $ cycstub --type region :TutorialLibrary:TutorialRegion
+    tutorial $ cycstub --type inst tutorial:TutorialLibrary:TutorialInstitution
+    tutorial $ cycstub --type region tutorial:TutorialLibrary:TutorialRegion
 
 ------------
 

--- a/source/arche/hello_world_cpp.rst
+++ b/source/arche/hello_world_cpp.rst
@@ -12,17 +12,22 @@ that you can use to quick-start new |cyclus| module development projects.
 available wherever ``cyclus`` is available.
 
 To use ``cycstub`` to generate the skeleton for a new Facility archetype named ``TutorialFacility`` in
-a module named ``tutorialfacility`` you can issue the following command:
+a module named ``TutorialLibrary`` you can issue the following command:
 
 .. code-block:: bash
 
-    tutorial $ mkdir TutorialFacility
-    tutorial $ cd TutorialFacility
-    TutorialFacility $ cycstub --type facility :tutorialfacility:TutorialFacility
+    tutorial $ cycstub --type facility :TutorialLibrary:TutorialFacility
 
-This will populate the ``TutorialFacility`` directory with a number of files and subdirectories
+This will populate the ``tutorial`` directory with a number of files and subdirectories
 that should already be complete for building a new archetype.  Without any changes, this archetype
-will not do anything.
+will not do anything, but will be a valid archetype for use in a simulation.
+
+You can add additional agents to this module by calling `cycstub` multiple times:
+
+.. code-block:: bash
+
+    tutorial $ cycstub --type inst :TutorialLibrary:TutorialInstitution
+    tutorial $ cycstub --type region :TutorialLibrary:TutorialRegion
 
 ------------
 

--- a/source/arche/hello_world_py.rst
+++ b/source/arche/hello_world_py.rst
@@ -71,7 +71,7 @@ an :file:`example.xml`. First modify it to point to the archetype we just wrote.
 Running |cyclus| on this file with the command
 ``cyclus input/example.xml`` should produce the following output.
 
-.. code-block:: bash
+.. code-block:: console
 
     tutorial $ cyclus input/example.xml
                   :

--- a/source/arche/hello_world_py.rst
+++ b/source/arche/hello_world_py.rst
@@ -73,7 +73,7 @@ Running |cyclus| on this file with the command
 
 .. code-block:: console
 
-    tutorial $ cyclus input/example.xml
+    $ cyclus input/example.xml
                   :
               .CL:CC CC             _Q     _Q  _Q_Q    _Q    _Q              _Q
             CC;CCCCCCCC:C;         /_\)   /_\)/_/\\)  /_\)  /_\)            /_\)

--- a/source/arche/logger.rst
+++ b/source/arche/logger.rst
@@ -3,7 +3,7 @@
 Logging
 =======================
 
-.. code-block:: bash
+.. code-block:: console
 
   LOG(LogLevel level, std::string prefix)
 

--- a/source/arche/module-cmake
+++ b/source/arche/module-cmake
@@ -1,4 +1,4 @@
-USE_CYCLUS("helloworld" "tutorial_facility")
-USE_CYCLUS("helloworld" "tutorial_inst")
-USE_CYCLUS("helloworld" "tutorial_region")
-INSTALL_CYCLUS_MODULE("helloworld" "tutorial")
+USE_CYCLUS("TutorialLibrary" "tutorial_facility")
+USE_CYCLUS("TutorialLibrary" "tutorial_inst")
+USE_CYCLUS("TutorialLibrary" "tutorial_region")
+INSTALL_CYCLUS_MODULE("TutorialLibrary" "")

--- a/source/arche/standalone-cmake
+++ b/source/arche/standalone-cmake
@@ -1,3 +1,3 @@
-INSTALL_CYCLUS_STANDALONE("TutorialFacility" "tutorial_facility" "tutorial")
-INSTALL_CYCLUS_STANDALONE("TutorialInst" "tutorial_inst" "tutorial")
-INSTALL_CYCLUS_STANDALONE("TutorialRegion" "tutorial_region" "tutorial")
+INSTALL_CYCLUS_STANDALONE("TutorialFacility" "tutorial_facility" "" )
+INSTALL_CYCLUS_STANDALONE("TutorialInstitution" "tutorial_inst" "")
+INSTALL_CYCLUS_STANDALONE("TutorialRegion" "tutorial_region" "")

--- a/source/arche/testing.rst
+++ b/source/arche/testing.rst
@@ -174,7 +174,7 @@ haven't already, now is a good time to add the ``$CYCLUS_INSTALL_PATH`` to your
 ``~/.local``). Next, from your top level directory (where your ``install.py``
 file is), run: 
 
-.. code-block:: bash
+.. code-block:: console
 
   $ ./install.py
   $ TickTracker_unit_tests
@@ -322,7 +322,7 @@ This will prevent exceptions from being caught resulting in a core-dump.  You
 can then use a debugger (e.g. gdb or lldb) to run the failing simulation and
 investigate the source of the crash in more detail.  Something like this:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ CYCLUS_NO_CATCH=1 gdb --args cyclus my-failing-sim.xml
     
@@ -339,7 +339,7 @@ with respect to resource exchange.  To turn on this debugging, simply run
 cyclus with the environment variable ``CYCLUS_DEBUG_DRE`` set to any non-empty
 value:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ CYCLUS_DEBUG_DRE=1 cyclus my-sim.xml
 

--- a/source/arche/tour_cpp.rst
+++ b/source/arche/tour_cpp.rst
@@ -2,15 +2,17 @@ A Tour of Cycstub
 =================
 
 Since |Cyclus| version 1.3.1 the Cycstub CLI is included in a standard |Cyclus| installation.
-If you have an older version of |Cyclus| please refer to the `Cycstub repository <https://github.com/cyclus/cycstub>`_
-for installation instructions.
-This section will walk through the source files of the stub :term:`archetypes
-<archetype>` in Cycstub. Cycstub provides
-three stub archetypes:
 
-* ``StubFacility``
-* ``StubInstitution``
-* ``StubRegion``
+This section will walk through the source files of the stub :term:`archetypes
+<archetype>` generated when a user invokes the ``cycstub`` utility.  ``Cycstub``
+can generate stubs for each of the agent types.  The standard usage to generate the 
+stubs for a Facility, Institution or Region, respectively, is:
+
+.. code-block:: bash
+
+  cycstub --type facility :stublibrary:StubFacility
+  cycstub --type institution :stublibrary:StubInstitution
+  cycstub --type region :stublibrary:StubRegion
 
 We will walk through ``StubFacility``\ 's source specifically because its the
 most complicated of the three. 
@@ -34,26 +36,32 @@ which includes most :term:`cyclus kernel` headers as a convenience for new
 include the specific kernel headers you need if you require a smaller
 executable.
 
-Moving on in the header file we come to the class declaration
+Moving on in the header file we come to the class declaration inside the namespace
+of this specific module library, `stublibrary`, with standard Doxygen documentation
+strings.
 
 .. code-block:: cpp
+
+  namespace stublibrary {
+
+  /// @class StubFacility
+  /// ...
 
   class StubFacility : public cyclus::Facility  {
 
 which simply states that the ``StubFacility`` inherits from ``cyclus::Facility``.
 
-We then come to the constructor declaration
+We then come to the constructor declaration in the header file
 
 .. code-block:: cpp
 
   explicit StubFacility(cyclus::Context* ctx);
 
-and implementation
+and definition in the implementation file
 
 .. code-block:: cpp
 
-  StubFacility::StubFacility(cyclus::Context* ctx)
-      : cyclus::Facility(ctx) {};
+  StubFacility::StubFacility(cyclus::Context* ctx) : cyclus::Facility(ctx) {};
 
 The constructor takes a single ``cyclus::Context`` argument. The :term:`context`
 is the mechanism by which :term:`agents <agent>` can query and otherwise

--- a/source/arche/tour_cpp.rst
+++ b/source/arche/tour_cpp.rst
@@ -8,7 +8,7 @@ This section will walk through the source files of the stub :term:`archetypes
 can generate stubs for each of the agent types.  The standard usage to generate the 
 stubs for a Facility, Institution or Region, respectively, is:
 
-.. code-block:: bash
+.. code-block:: console
 
   cycstub --type facility :stublibrary:StubFacility
   cycstub --type institution :stublibrary:StubInstitution

--- a/source/arche/tutorial_cpp/setup.rst
+++ b/source/arche/tutorial_cpp/setup.rst
@@ -42,7 +42,7 @@ following line to the end of it
 
 .. code-block:: console
 
-    install_cyclus_standalone("Storage" "storage" "tutorial")
+    $ install_cyclus_standalone("Storage" "storage" "tutorial")
 
 
 Install and Test

--- a/source/arche/tutorial_cpp/setup.rst
+++ b/source/arche/tutorial_cpp/setup.rst
@@ -40,7 +40,7 @@ Then make the new archetype, updating all the files as needed
 Finally, open -``src/CMakeLists.txt`` with your favorite text editor and add the
 following line to the end of it
 
-.. code-block:: bash
+.. code-block:: console
 
     install_cyclus_standalone("Storage" "storage" "tutorial")
 

--- a/source/arche/tutorial_py/setup.rst
+++ b/source/arche/tutorial_py/setup.rst
@@ -12,9 +12,9 @@ First let's start by making a tutorial example project with an ``agents.py`` fil
 
 .. code-block:: console
 
-    ~ $ mkdir -p tutorial/tut
-    ~ $ cd tutorial/tut
-    ~/tuorial/tut $ touch __init__.py agents.py
+    $ mkdir -p tutorial/tut
+    $ cd tutorial/tut
+    $ touch __init__.py agents.py
 
 
 Make a Storage Facility
@@ -68,17 +68,17 @@ Now we can install the tutorial project via,
 
 .. code-block:: console
 
-    ~ $ cd tutorial
-    ~/tutorial $ python -m pip install .
+    $ cd tutorial
+    $ python -m pip install .
 
 
 Let's now make an example input file in a special ``input`` directory:
 
 .. code-block:: console
 
-    ~ $ cd tutorial
-    ~/tutorial $ mkdir -p input
-    ~/tutorial $ touch input/storage.py
+    $ cd tutorial
+    $ mkdir -p input
+    $ touch input/storage.py
 
 Now open up the ``input/storage.py`` input file and edit it to look like:
 

--- a/source/arche/tutorial_py/state_var.rst
+++ b/source/arche/tutorial_py/state_var.rst
@@ -77,7 +77,7 @@ To reinstall this module, just issue the same ``setup.py`` command as before:
 
 .. code-block:: console
 
-    ~/tutorial $ python setup.py install --user
+    $ python setup.py install --user
 
 
 Modify the Input File
@@ -88,7 +88,7 @@ to define your module.  It is missing the new variables.  Try it:
 
 .. code-block:: console
 
-    ~/tutorial $ cyclus -v 2 input/storage.py
+    $ cyclus -v 2 input/storage.py
                   :
               .CL:CC CC             _Q     _Q  _Q_Q    _Q    _Q              _Q
             CC;CCCCCCCC:C;         /_\)   /_\)/_/\\)  /_\)  /_\)            /_\)
@@ -125,7 +125,7 @@ The simulation now fails because it does not match the schema. You can view the 
 
 .. code-block:: console
 
-    ~/tutorial $ cyclus --agent-schema :tut.agents:Storage
+    $ cyclus --agent-schema :tut.agents:Storage
 
 Notice that you were able to take advantage of the input file validation simply by using
 the special ``typesystem`` class attributes.
@@ -134,7 +134,7 @@ Our failed cyclus simulation produced an output file that will need to be delete
 
 .. code-block:: console
 
-    ~/tutorial $ rm cyclus.sqlite
+    $ rm cyclus.sqlite
 
 Now, we'll change that input file.  Open the file ``input/storage.py`` in
 your text editor, and find the prototype configuration for the single facility
@@ -172,7 +172,7 @@ Now we can try it again:
 
 .. code-block:: console
 
-    ~/tutorial $ cyclus -v 2 input/storage.py
+    $ cyclus -v 2 input/storage.py
                   :
               .CL:CC CC             _Q     _Q  _Q_Q    _Q    _Q              _Q
             CC;CCCCCCCC:C;         /_\)   /_\)/_/\\)  /_\)  /_\)            /_\)

--- a/source/arche/tutorial_py/toolkit.rst
+++ b/source/arche/tutorial_py/toolkit.rst
@@ -75,7 +75,7 @@ You can also confirm that everything still works with running the simulation:
 
 .. code-block:: console
 
-    ~/tutorial $ cyclus -v 3 input/storage.py
+    $ cyclus -v 3 input/storage.py
                   :
               .CL:CC CC             _Q     _Q  _Q_Q    _Q    _Q              _Q
             CC;CCCCCCCC:C;         /_\)   /_\)/_/\\)  /_\)  /_\)            /_\)

--- a/source/cep/cep3.rst
+++ b/source/cep/cep3.rst
@@ -142,7 +142,7 @@ Release Process
 
     - make sure to have your ``rs.cred`` file (see ``maintenance.sh``'s help)
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ cd /path/to/release/utils
       $ export CYCLUS_DIR=/path/to/cyclus
@@ -163,7 +163,7 @@ Release Process
           #. if the dev-list agrees to those changes, update the symbols and
              commit the new one:
 
-          .. code-block:: bash
+          .. code-block:: console
 
                 $ cd $CYCLUS_DIR/release
                 $ ./smbchk.py --update -t X.X.X # X.X.X is *this* version
@@ -173,7 +173,7 @@ Release Process
 
 #. Commit all changes for all projects.
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ cd /path/to/project
       $ git checkout vX.X.X-release
@@ -181,7 +181,7 @@ Release Process
 
 #. Update all master branches.
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ cd /path/to/project
       $ git checkout master
@@ -190,7 +190,7 @@ Release Process
 
 #. *Locally* tag the repository for *each* of the projects.
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ cd /path/to/project
       $ git checkout master
@@ -202,7 +202,7 @@ Release Process
     - the ``make_release_notes.sh`` utility in ``release/utils`` will help
       provide a template
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ cd /path/to/release/utils
       $ export CYCLUS_DIR=/path/to/cyclus
@@ -218,7 +218,7 @@ Release Process
     - the ``api_docs.sh`` utility in ``release/utils`` will do this
       automatically for you
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ cd /path/to/release/utils
       $ export CYCLUS_DIR=/path/to/cyclus
@@ -227,7 +227,7 @@ Release Process
 
 #. Update the ``master`` branch of all projects and clean up.
 
-    .. code-block:: bash
+    .. code-block:: console
 
       $ cd /path/to/project
       $ git push upstream X.X.X master
@@ -293,7 +293,7 @@ Release Process
    have to be compiled on you system and both executable and lib have to be on
    the default paths. Please refer to the :doc:`source installation
    <../user/install_from_git>` if you need.
-.. .. code-block:: bash
+.. .. code-block:: console
       $ git clone https://github.com/rwcarlsen/cloudlus.git
       $ cd cloudlus
       $ go install ./cmd/cloudlus
@@ -327,7 +327,7 @@ evolves, we'll want to have our version evolve as well. Here are the steps to do
 These assume that in your HOME dir there are both the pyne and |cyclus| repos.  Remember
 to check in the changes afterwards.
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd ~/pyne
     $ ./amalgamate.py -s pyne.cc -i pyne.h
@@ -337,7 +337,7 @@ to check in the changes afterwards.
 our source data.  Occassionally, this needs to be updated as updates to pyne itself come out.
 The command for generating |cyclus| specific nuclear data is as follows:
 
-.. code-block:: bash
+.. code-block:: console
 
    $ cd ~/pyne
    $ nuc_data_make -o cyclus_nuc_data.h5 \
@@ -357,7 +357,7 @@ automatically.  In order to check this correctly, you must have a **RELEASE**
 build of Cyclus compiled/installed.  Every release please run the following
 command to verify that the release branch is stable:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd cyclus/release
     $ ./smbchk.py --update -t HEAD --no-save --check
@@ -374,7 +374,7 @@ Once stable and there are no more code changes to be made, add the symbols
 in this release to the database with the following command (again - make sure
 you are working on a RELEASE build of Cyclus):
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cd cyclus/release
     $ ./smbchk.py --update -t X.X.X

--- a/source/user/cymetric/tutorial_cli.rst
+++ b/source/user/cymetric/tutorial_cli.rst
@@ -28,7 +28,7 @@ Since cymetric is wholly dependent on |cyclus| databases, you must supply a
 database as an argument on the command line. This will look something like the
 following:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cymetric database -flags
 
@@ -46,7 +46,7 @@ database.  Note that this may list more tables in the database than are
 strictly part of the |cyclus| interface, because of the need for |cyclus| to
 store metadata. Don't be alarmed. Listing the current tables is easy:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cymetric test.h5 -l
     AgentEntry
@@ -90,7 +90,7 @@ can use. Indexing the table variables will return the metric as a `pandas
 ``AgentEntry`` table, we would write ``AgentEntry[:]`` to get the table and
 ``print(AgentEntry[:])`` to display it after the ``-e`` flag:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cymetric test.h5 -e "print(AgentEntry[:])"
                                       SimId  AgentId      Kind                    Spec          Prototype  ParentId  Lifetime  EnterTime
@@ -109,7 +109,7 @@ Indexing a metric with an empty slice (``[:]``), none (``[None]``), or an ellips
 filters on the column names. The column names of the metric are thus also available for
 use.  For example, let's just grab all of the facilities out of the entry table:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cymetric test.h5 -e "print(AgentEntry[Kind == 'Facility'])"
                                       SimId  AgentId      Kind                    Spec   Prototype  ParentId  Lifetime  EnterTime
@@ -124,7 +124,7 @@ use.  For example, let's just grab all of the facilities out of the entry table:
 Separate the conditions by commas (``,``) to apply multiple filters at the same
 time:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cymetric test.h5 -e "print(AgentEntry[Kind == 'Facility', AgentId > 14])"
                                       SimId  AgentId      Kind                    Spec Prototype  ParentId  Lifetime  EnterTime
@@ -139,7 +139,7 @@ able to do in Python. Suppose that we have a ``Materials`` metric with a ``Mass`
 column. We can compute this metric, pull the column out, multiply it by 42,
 save the result to a variable, and then print this variable all via the following.
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cymetric test.h5 -e "mass = Materials[:]['Mass'] * 42; print(mass)"
     0      0.000000
@@ -192,7 +192,7 @@ Module                Alias
 This let's you do neat things such as plot the metrics right from the command line.
 For example,
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cymetric test.h5 -e "Materials[ResourceId == 15].plot(x='NucId', y='Mass', kind='bar'); plt.show()"
 
@@ -210,7 +210,7 @@ default functionality when you use the ``-e`` flag, the lack of writing
 can be accomplished with the ``--no-write`` flag. In the example below, the
 table will not be written to the database:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cymetric test.h5 --no-write -e "Materials[:]"
 
@@ -218,7 +218,7 @@ Since cymetric looks up an already evaluated metric in the database,
 overwriting an existing table with a new one might be desired. This is where
 the ``--write`` flag is useful:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cymetric test.h5 --write -e "Materials[:]"
 

--- a/source/user/find_agents.rst
+++ b/source/user/find_agents.rst
@@ -72,7 +72,7 @@ and on the command line. For example, to print out the schema for an agent
 archetype on the command line (note the starting colon indicating an empty
 path):
 
-.. code-block:: bash
+.. code-block:: console
 
     cyclus --agent-schema :agents:KFacility
 
@@ -86,7 +86,7 @@ directories, it is possible to manually specify other directories for |Cyclus|
 to search by adding them as colon-separated entries to the CYCLUS_PATH
 environment variable.  For example:
 
-.. code-block:: bash
+.. code-block:: console
 
     export CYCLUS_PATH=my/agent/lib/dir:/my/other/agent/dir
 

--- a/source/user/install.rst
+++ b/source/user/install.rst
@@ -52,7 +52,7 @@ Try running |Cyclus| for yourself. The result will be a :doc:`database <dbdoc>` 
 Use your favorite sqlite browser to peruse, or explore the data using 
 `Cymetric <https://github.com/cyclus/cymetric>`_.
 
-.. code-block:: bash
+.. code-block:: console
 
    $ cyclus ~/path/to/cycamore/input/recycle.xml
 

--- a/source/user/install_binary.rst
+++ b/source/user/install_binary.rst
@@ -26,7 +26,7 @@ At this point |Cyclus| should be successfully installed on your system and you a
 
 #. Install the package by running:
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ sudo dpkg -i cycamore-x.x.x-Linux.deb
 

--- a/source/user/install_docker.rst
+++ b/source/user/install_docker.rst
@@ -36,7 +36,7 @@ These images are updated via GitHub actions and have the following supported tag
 
 You can download and run a container image interactively using:
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ docker run -it ghcr.io/cyclus/cyclus_22.04_apt/cyclus:stable
 

--- a/source/user/install_from_git.rst
+++ b/source/user/install_from_git.rst
@@ -31,7 +31,7 @@ Install Cyclus
 Get the Source Code from the Git Repo
 =====================================
 
-.. code-block:: bash
+.. code-block:: console
 
   git clone https://github.com/cyclus/cyclus .
   git fetch
@@ -56,7 +56,7 @@ Install Cycamore
 Get the Source Code from the Git Repo
 =====================================
 
-.. code-block:: bash
+.. code-block:: console
 
   git clone https://github.com/cyclus/cycamore .
   git fetch

--- a/source/user/running_sims.rst
+++ b/source/user/running_sims.rst
@@ -3,19 +3,19 @@ Running Simulations
 
 To run a simulation you must use the |cyclus| command line utility:
 
-.. code-block:: bash
+.. code-block:: console
 
   $ ./path/to/cyclus [options] [input-file]
 
 Or you may run directly through Python:
 
-.. code-block:: bash
+.. code-block:: console
 
   $ python -m cyclus [options] [input-file]
 
 For more information, please refer to the help:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cyclus -h
     Usage:   cyclus [opts] [input-file]
@@ -57,7 +57,7 @@ For more information, please refer to the help:
 Examples
 ++++++++
 
-.. code-block:: bash
+.. code-block:: console
 
   $ cyclus ./path/to/myinput.xml
 

--- a/source/user/server.rst
+++ b/source/user/server.rst
@@ -12,13 +12,13 @@ the server itself.
 
 To start up the Cyclus server, use the following command line utility, spawned via Python.
 
-.. code-block:: bash
+.. code-block:: console
 
     $ python -m cyclus.server
 
 For more information, please refer to the help:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ python -m cyclus.server -h
     usage: cyclus [-h] [-o OUTPUT_PATH] [--debug] [--host HOST] [-p PORT]
@@ -49,7 +49,7 @@ For more information, please refer to the help:
 Examples
 ---------
 
-.. code-block:: bash
+.. code-block:: console
 
     # Run an input file in server mode, returning all of the output
       # table data over the websocket each time step.
@@ -66,7 +66,7 @@ Cyclus also ships with a simple web application that is an example client for Cy
 You may start this web app (after starting Cyclus Server) with the following command in a new
 terminal:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ python -m cyclus.webapp
 

--- a/source/user/sim_schema.rst
+++ b/source/user/sim_schema.rst
@@ -12,7 +12,7 @@ Region, Institution, and Facility hierarchy that is natural for modeling
 the relationship between different actors in the nuclear fuel cycle.  You 
 can print this schema from the command line with the ``--schema`` option:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cyclus --schema
 
@@ -189,7 +189,7 @@ collections of facilities in cases where regional and institutional effects
 are not of primary interest.  You can print this from the command line 
 with the combination of the ``--schema`` and ``--flat-schema`` options:
 
-.. code-block:: bash
+.. code-block:: console
 
     $ cyclus --flat-schema --schema
 

--- a/source/user/unit_test.rst
+++ b/source/user/unit_test.rst
@@ -2,7 +2,7 @@ To ensure the proper installation of |Cyclus| and Cycamore, you can run the
 |Cyclus| and Cycamore unit tests, they should report that **all tests** have
 **passed** (or been disabled):
 
-.. code-block:: bash 
+.. code-block:: console 
 
   $ cyclus_unit_tests
   $ cycamore_unit_tests


### PR DESCRIPTION
This removes references to the cycstub repo and instead replaces it with reference to the cycstub utility.  This leaves one file untouched because it is slated to be removed in #418 .

`cmake.rst` still needs a closer review, but this could be left to a different PR??

Fixes #197 and #366