### PR TITLE
Update input file names

### DIFF
--- a/source/user/tutorial/add_deploy.rst
+++ b/source/user/tutorial/add_deploy.rst
@@ -131,7 +131,6 @@ institution blocks.
 ``ExampleInstitution`` is a placeholder for your institution name, and in this scenario
 only one of each prototype will be deployed since ``n_build`` has a value of 1 for each.
 
-This example is now complete. Save your file as the desired file name (with ``.xml`` 
-extension) and run your code through |Cyclus|. If your simulation runs into errors, 
+This example is now complete. Save your file as 'tutorial_deployinst.xml' and run your code through |Cyclus|. If your simulation runs into errors, 
 sample files can be found `here <https://doi.org/10.5281/zenodo.4557613>`_ under 
 ``input_deployinst.xml`` or ``output_deployinst.sqlite``.

--- a/source/user/tutorial/add_deploy.rst
+++ b/source/user/tutorial/add_deploy.rst
@@ -131,6 +131,6 @@ institution blocks.
 ``ExampleInstitution`` is a placeholder for your institution name, and in this scenario
 only one of each prototype will be deployed since ``n_build`` has a value of 1 for each.
 
-This example is now complete. Save your file as 'tutorial_deployinst.xml' and run your code through |Cyclus|. If your simulation runs into errors, 
+This example is now complete. Save your file as ``tutorial_deployinst.xml`` and run your code through |Cyclus|. If your simulation runs into errors, 
 sample files can be found `here <https://doi.org/10.5281/zenodo.4557613>`_ under 
 ``input_deployinst.xml`` or ``output_deployinst.sqlite``.

--- a/source/user/tutorial/add_reg_inst.rst
+++ b/source/user/tutorial/add_reg_inst.rst
@@ -472,7 +472,7 @@ Activity: Save your Input File
 
 You are now ready to generate a full |Cyclus| input file.
 
-1. Save your input file as 'tutorial_oncethrough.xml'
+1. Save your input file as ``tutorial_oncethrough.xml``
 
 
 Check: Full Input File

--- a/source/user/tutorial/add_reg_inst.rst
+++ b/source/user/tutorial/add_reg_inst.rst
@@ -353,7 +353,7 @@ Check: Complete Region block
 Activity: Save your input file
 ------------------------------
 
-Save your input file as ``cyclus_intro_file.xml``
+Save your input file as ``tutorial_oncethrough.xml``
 
 
 Activity: Add an extra institution into the Region

--- a/source/user/tutorial/add_reg_inst.rst
+++ b/source/user/tutorial/add_reg_inst.rst
@@ -472,7 +472,7 @@ Activity: Save your Input File
 
 You are now ready to generate a full |Cyclus| input file.
 
-1. Save your input file as 'cyclus_intro_file.xml'
+1. Save your input file as 'tutorial_oncethrough.xml'
 
 
 Check: Full Input File

--- a/source/user/tutorial/add_second_reactor.rst
+++ b/source/user/tutorial/add_second_reactor.rst
@@ -119,7 +119,7 @@ of the region block should now look like,
 Note: the blank space between ``</institution>`` and ``</region>`` is
 for additional institutions in the future.
 
-Save your input file as 'tutorial_secondreactor.xml' and run the |Cyclus| simulation.
+Save your input file as ``tutorial_secondreactor.xml`` and run the |Cyclus| simulation.
 If your simulation runs into errors, sample files can be found `here 
 <https://doi.org/10.5281/zenodo.4557613>`_ under ``input_secondreactor.xml`` 
 or ``ouput_secondreactor.sqlite``.

--- a/source/user/tutorial/add_second_reactor.rst
+++ b/source/user/tutorial/add_second_reactor.rst
@@ -119,7 +119,7 @@ of the region block should now look like,
 Note: the blank space between ``</institution>`` and ``</region>`` is
 for additional institutions in the future.
 
-Save your input file as input_file2.xml and run the |Cyclus| simulation.
+Save your input file as 'tutorial_secondreactor.xml' and run the |Cyclus| simulation.
 If your simulation runs into errors, sample files can be found `here 
 <https://doi.org/10.5281/zenodo.4557613>`_ under ``input_secondreactor.xml`` 
 or ``ouput_secondreactor.sqlite``.

--- a/source/user/tutorial/mod_rxtr.rst
+++ b/source/user/tutorial/mod_rxtr.rst
@@ -33,7 +33,7 @@ Add an accepted commodity for the repository to be Separated-Waste.
 
 Activity: Save your Input File
 --------------------
-The input for this example is now complete. Save your input file as 'tutorial_recycle.xml'. If 
+The input for this example is now complete. Save your input file as ``tutorial_recycle.xml``. If 
 your simulation runs into errors, sample files can be found `here 
 <https://doi.org/10.5281/zenodo.4557613>`_ under ``input_recycle.xml`` 
 or ``ouput_recycle.sqlite``.

--- a/source/user/tutorial/mod_rxtr.rst
+++ b/source/user/tutorial/mod_rxtr.rst
@@ -33,7 +33,7 @@ Add an accepted commodity for the repository to be Separated-Waste.
 
 Activity: Save your Input File
 --------------------
-The input for this example is now complete. Save your input file as 'recycle_input.xml'. If 
+The input for this example is now complete. Save your input file as 'tutorial_recycle.xml'. If 
 your simulation runs into errors, sample files can be found `here 
 <https://doi.org/10.5281/zenodo.4557613>`_ under ``input_recycle.xml`` 
 or ``ouput_recycle.sqlite``.

--- a/source/user/tutorial/run_cyclus_native.rst
+++ b/source/user/tutorial/run_cyclus_native.rst
@@ -55,13 +55,13 @@ Jupyter Notebook Scenario Execution
 --------------------------------------------
 1. Go to the Jupyter notebook, making sure you are in the same folder as the input file
 2. Remove any old |Cyclus| output files by: ``!rm tutorial.sqlite``
-3. Run |Cyclus| by: ``!cyclus input.xml -o tutorial_singlerx.sqlite``
+3. Run |Cyclus| by: ``!cyclus tutorial_oncethrough.xml -o tutorial_output_oncethrough.sqlite``
 
 .. image:: cyclus_in_IP.png
     :align: center
     :alt: Running |Cyclus| in an IPython Notebook
 
-When your simulation has finished, a file of the name ``tutorial_singlerx.sqlite`` 
+When your simulation has finished, a file of the name ``tutorial_output_oncethrough.sqlite`` 
 will be in your file folder. Your Jupyter Notebook can then be used with 
 `Cymetric <https://fuelcycle.org/user/cymetric/index.html>`_ to analyze your 
 data. Examples of how to use Cymetric can be found in the `GitHub 


### PR DESCRIPTION
<!-- If this PR adds a CEP, do not repeat all of the information in the CEP document in the summary. Instead, provide a short description of the CEP's purpose.  -->

# Summary of Changes
This PR addresses #440 by updating file names. The input files that users are instructed to save as they complete the tutorials now follow the format `tutorial_[tutorial name].xml`, and the tutorial names mirror the names for the input files in the Zenodo object. One output file name was also changed in the instructions for running in a Jupyter notebook, following a similar format.


## Design Notes



Check the box if your change does not break any of the following:
- [x] API for Cyclus modules
- [x] Input files
- [x] Output tables for post processing tools

# Related CEPs and Issues
<!--- Reference the issue that this PR closes, any related CEPs, and describe how this PR contributes to or addresses the problem. -->
Fixes #440 


# Associated Developers
<!--- Please mention any developers who should be alerted of this PR. -->



# Testing and Validation
<!--- Describe how this change was tested. -->


- [x] I have read the [Contributing to Cyclus](https://fuelcycle.org/kernel/contributing_to_cyclus.html) guide
- [ ] I have compiled and run the code locally
- [ ] I have added or updated relevant tests
- [ ] I have added documentation for new or changed features
- [ ] This code follows the style guide
- [ ] I have updated the changelog

Reviewers, please refer to the Cyclus [Guide for Reviewers](https://fuelcycle.org/kernel/pr_review.html).